### PR TITLE
Don't ignore custom boards.txt path when using a custom ard-parse-boards...

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -173,6 +173,9 @@ endif
 
 ########################################################################
 
+# The path directory this Makefile is stored in
+ARDUINO_MK_PATH := $(dir $(lastword $(MAKEFILE_LIST)))
+
 #
 # Arduino version number
 ifndef ARDUINO_VERSION
@@ -214,8 +217,16 @@ ifndef BOARDS_TXT
 BOARDS_TXT  = $(ARDUINO_DIR)/hardware/arduino/boards.txt
 endif
 
+ifndef PARSE_BOARD_OPTS
+PARSE_BOARD_OPTS = --boards_txt=$(BOARDS_TXT)
+endif
+
+ifndef PARSE_BOARD_PATH
+PARSE_BOARD_PATH = $(ARDUINO_MK_PATH)/ard-parse-boards
+endif
+
 ifndef PARSE_BOARD
-PARSE_BOARD = ard-parse-boards --boards_txt=$(BOARDS_TXT)
+PARSE_BOARD = $(PARSE_BOARD_PATH) $(PARSE_BOARD_OPTS)
 endif
 
 # Which variant ? This affects the include path

--- a/examples/Blink/Makefile
+++ b/examples/Blink/Makefile
@@ -1,5 +1,4 @@
 ARDUINO_DIR = /Applications/Arduino.app/Contents/Resources/Java
-PARSE_BOARD = ../../arduino-mk/ard-parse-boards
 
 BOARD_TAG    = uno
 ARDUINO_PORT = /dev/cu.usb*

--- a/examples/BlinkWithoutDelay/Makefile
+++ b/examples/BlinkWithoutDelay/Makefile
@@ -1,5 +1,4 @@
 ARDUINO_DIR = /Applications/Arduino.app/Contents/Resources/Java
-PARSE_BOARD = ../../arduino-mk/ard-parse-boards
 
 BOARD_TAG    = uno
 ARDUINO_PORT = /dev/cu.usb*

--- a/examples/Fade/Makefile
+++ b/examples/Fade/Makefile
@@ -1,5 +1,4 @@
 ARDUINO_DIR = /Applications/Arduino.app/Contents/Resources/Java
-PARSE_BOARD = ../../arduino-mk/ard-parse-boards
 
 BOARD_TAG    = uno
 ARDUINO_PORT = /dev/cu.usb*

--- a/examples/HelloWorld/Makefile
+++ b/examples/HelloWorld/Makefile
@@ -1,6 +1,3 @@
-ARDUINO_DIR = /Applications/Arduino.app/Contents/Resources/Java
-PARSE_BOARD = ../../arduino-mk/ard-parse-boards
-
 BOARD_TAG    = uno
 ARDUINO_PORT = /dev/cu.usb*
 

--- a/examples/WebServer/Makefile
+++ b/examples/WebServer/Makefile
@@ -1,5 +1,4 @@
 ARDUINO_DIR = /Applications/Arduino.app/Contents/Resources/Java
-PARSE_BOARD = ../../arduino-mk/ard-parse-boards
 
 BOARD_TAG    = uno
 ARDUINO_PORT = /dev/cu.usb*

--- a/examples/master_reader/Makefile
+++ b/examples/master_reader/Makefile
@@ -1,5 +1,4 @@
 ARDUINO_DIR = /Applications/Arduino.app/Contents/Resources/Java
-PARSE_BOARD = ../../arduino-mk/ard-parse-boards
 
 BOARD_TAG    = uno
 ARDUINO_PORT = /dev/cu.usb*

--- a/examples/toneMelody/Makefile
+++ b/examples/toneMelody/Makefile
@@ -1,5 +1,4 @@
 ARDUINO_DIR = /Applications/Arduino.app/Contents/Resources/Java
-PARSE_BOARD = ../../arduino-mk/ard-parse-boards
 
 BOARD_TAG    = uno
 ARDUINO_PORT = /dev/cu.usb*


### PR DESCRIPTION
This splits the definition of the path to ard-parse-boards from the arguments
passed to it - most importantly the custom path to the boards.txt which changes
on different platforms. The default value for this hard-coded into
ard-parse-boards won't work in Linux or Windows, so passing the custom value is
critical.

This change also determines the absolute path to ard-parse-boards dynamically,
so the PARSE_BOARDS_PATH value should never really need to be overridden. I
removed the custom values from all of the example Makefiles.
