### PR TITLE
Add a flag for stopping compilation of built-in main() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ documentation](http://mjo.tc/atelier/2009/02/arduino-cli.html
 "Documentation") exists.
 
 If you're using Debian or Ubuntu, you can find this in the arduino-core package.
+
+## Options
+
+If you are defining your own `main()` function, you can stop the Ardunio's
+built-in `main()` from being compiled with your code by defining the
+`NO_CORE_MAIN_FUNCTION` variable:
+
+    NO_CORE_MAIN_FUNCTION = 1

--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -287,6 +287,11 @@ ifeq ($(strip $(NO_CORE)),)
 ifdef ARDUINO_CORE_PATH
 CORE_C_SRCS     = $(wildcard $(ARDUINO_CORE_PATH)/*.c)
 CORE_CPP_SRCS   = $(wildcard $(ARDUINO_CORE_PATH)/*.cpp)
+
+ifneq ($(strip $(NO_CORE_MAIN_FUNCTION)),)
+CORE_CPP_SRCS := $(filter-out %main.cpp, $(CORE_CPP_SRCS))
+endif
+
 CORE_OBJ_FILES  = $(CORE_C_SRCS:.c=.o) $(CORE_CPP_SRCS:.cpp=.o)
 CORE_OBJS       = $(patsubst $(ARDUINO_CORE_PATH)/%,  \
 			$(OBJDIR)/%,$(CORE_OBJ_FILES))


### PR DESCRIPTION
If you need to define your own main() function, e.g. if you are using Xcode and
want the code sense to work, you can flip this flag on to stop the Makefile from
compiling the Arduino's built-in main.cpp file.
