### PR TITLE
Fix for using --boards_txt on Linux.

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -243,46 +243,46 @@ endif
 
 # Which variant ? This affects the include path
 ifndef VARIANT
-VARIANT = $(shell $(PARSE_BOARD) $(BOARD_TAG) build.variant)
+VARIANT = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) build.variant)
 endif
 
 # processor stuff
 ifndef MCU
-MCU   = $(shell $(PARSE_BOARD) $(BOARD_TAG) build.mcu)
+MCU   = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) build.mcu)
 endif
 
 ifndef F_CPU
-F_CPU = $(shell $(PARSE_BOARD) $(BOARD_TAG) build.f_cpu)
+F_CPU = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) build.f_cpu)
 endif
 
 # normal programming info
 ifndef AVRDUDE_ARD_PROGRAMMER
-AVRDUDE_ARD_PROGRAMMER = $(shell $(PARSE_BOARD) $(BOARD_TAG) upload.protocol)
+AVRDUDE_ARD_PROGRAMMER = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) upload.protocol)
 endif
 
 ifndef AVRDUDE_ARD_BAUDRATE
-AVRDUDE_ARD_BAUDRATE   = $(shell $(PARSE_BOARD) $(BOARD_TAG) upload.speed)
+AVRDUDE_ARD_BAUDRATE   = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) upload.speed)
 endif
 
 # fuses if you're using e.g. ISP
 ifndef ISP_LOCK_FUSE_PRE
-ISP_LOCK_FUSE_PRE  = $(shell $(PARSE_BOARD) $(BOARD_TAG) bootloader.unlock_bits)
+ISP_LOCK_FUSE_PRE  = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) bootloader.unlock_bits)
 endif
 
 ifndef ISP_LOCK_FUSE_POST
-ISP_LOCK_FUSE_POST = $(shell $(PARSE_BOARD) $(BOARD_TAG) bootloader.lock_bits)
+ISP_LOCK_FUSE_POST = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) bootloader.lock_bits)
 endif
 
 ifndef ISP_HIGH_FUSE
-ISP_HIGH_FUSE      = $(shell $(PARSE_BOARD) $(BOARD_TAG) bootloader.high_fuses)
+ISP_HIGH_FUSE      = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) bootloader.high_fuses)
 endif
 
 ifndef ISP_LOW_FUSE
-ISP_LOW_FUSE       = $(shell $(PARSE_BOARD) $(BOARD_TAG) bootloader.low_fuses)
+ISP_LOW_FUSE       = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) bootloader.low_fuses)
 endif
 
 ifndef ISP_EXT_FUSE
-ISP_EXT_FUSE       = $(shell $(PARSE_BOARD) $(BOARD_TAG) bootloader.extended_fuses)
+ISP_EXT_FUSE       = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) bootloader.extended_fuses)
 endif
 
 # Everything gets built in here
@@ -548,7 +548,7 @@ size:		$(OBJDIR) $(TARGET_HEX)
 		$(SIZE) $(TARGET_HEX)
 
 show_boards:	
-		$(PARSE_BOARD) --boards
+		$(PARSE_BOARD_CMD) --boards
 
 .PHONY:	all clean depends upload raw_upload reset size show_boards
 


### PR DESCRIPTION
The --boards_txt argument was never being passed onto ard-parse-boards even though the command was being constructed in PARSE_BOARD_CMD.

PARSE_BOARD_CMD was never used in the rest of the makefile. I've changed all relevant instances of PARSE_BOARD to PARSE_BOARD_CMD.
