### PR TITLE
Fix build on Leonardo (missing USB_VID and USB_PID)

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -387,6 +387,14 @@ ifndef F_CPU
 F_CPU = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) build.f_cpu)
 endif
 
+ifndef VID
+VID = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) build.vid)
+endif
+
+ifndef PID
+PID = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) build.pid)
+endif
+
 # normal programming info
 ifndef AVRDUDE_ARD_PROGRAMMER
 AVRDUDE_ARD_PROGRAMMER = $(shell $(PARSE_BOARD_CMD) $(BOARD_TAG) upload.protocol)
@@ -494,7 +502,7 @@ LIB_OBJS      = $(patsubst $(ARDUINO_LIB_PATH)/%.c,$(OBJDIR)/libs/%.o,$(LIB_C_SR
 USER_LIB_OBJS = $(patsubst $(USER_LIB_PATH)/%.cpp,$(OBJDIR)/libs/%.o,$(USER_LIB_CPP_SRCS)) \
 		$(patsubst $(USER_LIB_PATH)/%.c,$(OBJDIR)/libs/%.o,$(USER_LIB_C_SRCS))
 
-CPPFLAGS      = -mmcu=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) \
+CPPFLAGS      = -mmcu=$(MCU) -DUSB_VID=$(VID) -DUSB_PID=$(PID) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) \
 			-I. -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
 			$(SYS_INCLUDES) $(USER_INCLUDES) -g -Os -w -Wall \
 			-ffunction-sections -fdata-sections


### PR DESCRIPTION
I don't have any other Arduino to test, but on Leonardo, new parameters have been introduced (USB_VID and USB_PID). Here's a patch to add them.
Again, needs testing on other boards than the Leonardo.
