### PR TITLE
Update ard-parse-boards to use ARDUINO_DIR

### DIFF
--- a/bin/ard-parse-boards
+++ b/bin/ard-parse-boards
@@ -9,7 +9,7 @@ use YAML;
 
 my %Opt = 
   (
-   boards_txt => '/Applications/Arduino.app/Contents/Resources/Java/hardware/arduino/boards.txt',
+   boards_txt => "$ENV{'ARDUINO_DIR'}/hardware/arduino/boards.txt",
   );
 
 GetOptions(\%Opt,


### PR DESCRIPTION
Update boards_txt path in bin/ard-parse-boards to include environment variable ARDUINO_DIR

This corrects the behaviour of  ard-parse-boards --boards  , which would fail if the path to boards.txt on the system didn't match the value which was hardcoded.
