### PR TITLE
Changed shebang to use /usr/bin/env

### DIFF
--- a/bin/ard-parse-boards
+++ b/bin/ard-parse-boards
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#! /usr/bin/env perl
 
 use strict;
 use warnings;

--- a/bin/ard-reset-arduino
+++ b/bin/ard-reset-arduino
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#! /usr/bin/env perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
Use /usr/bin/env instead of hardcoded perl location.

This is necessary for users of perlbrew, and probably many other cases.
