### PR TITLE
Refer to original file in error messages.

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -599,6 +599,7 @@ $(OBJDIR)/%.cpp: %.pde
 # the ino -> cpp -> o file
 $(OBJDIR)/%.cpp: %.ino
 	$(ECHO) '#include <Arduino.h>' > $@
+	$(ECHO) '#line 1 "$<"' > $@
 	$(CAT)  $< >> $@
 
 $(OBJDIR)/%.o: $(OBJDIR)/%.cpp


### PR DESCRIPTION
On the documentation page it says:

   When compiling the sketch file, the compiler actually sees the .cpp file derived from it. Accordingly the line numbers of any errors will be wrong (but not by that much).

This pull request addresses that so the error messages refer to the original file, and clicking on it in editors such as emacs' "compilation mode" will go to the right place.
