### PR TITLE
ARDUINO_USR_LIB vs ARDUINO_LIB

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -507,7 +507,7 @@ ECHO    = echo
 
 # General arguments
 SYS_LIBS      = $(patsubst %,$(ARDUINO_LIB_PATH)/%,$(ARDUINO_LIBS))
-USER_LIBS     = $(patsubst %,$(USER_LIB_PATH)/%,$(ARDUINO_LIBS))
+USER_LIBS     = $(patsubst %,$(USER_LIB_PATH)/%,$(ARDUINO_USR_LIBS))
 SYS_INCLUDES  = $(patsubst %,-I%,$(SYS_LIBS))
 USER_INCLUDES = $(patsubst %,-I%,$(USER_LIBS))
 LIB_C_SRCS    = $(wildcard $(patsubst %,%/*.c,$(SYS_LIBS)))


### PR DESCRIPTION
i made this change on my forked copy of your project to allow me to distinguish between system libraries that come with Arduino.app and libraries i've installed to experiment with.

the change required you to tweak your Makefile's.   

for example, for a BlinkM project i'm playing with i have:

--snip--
ARDUINO_LIBS = Wire Wire/utility 
ARDUINO_USR_LIBS = BlinkM
--snip--

if you think this feature would be generally useful, it'd be great if you could merge it into your project.

jeff o'connell
@jefforulez
