### PR TITLE
Update to Ubuntu package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ need the YAML library to run ard-parse-boards.
 
 On Debian or Ubuntu:
 
-       apt-get install libdevice-serial-perl
+       apt-get install libdevice-serialport-perl
        apt-get install libyaml-perl
 
 On Fedora:


### PR DESCRIPTION
It looks like one of the package names has changed (from libdevice-serial-perl to libdevice-serialport-perl)

Thanks for putting this together and maintaining it!
