### PR TITLE
AUTO_ARDUINO_VERSION proposed fix (mk2)

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -257,7 +257,7 @@ ifndef ARDUINO_VERSION
     # Remove all the decimals, and right-pad with zeros, and finally grab the first 3 bytes.
     # Works for 1.0 and 1.0.1
     VERSION_FILE := $(ARDUINO_DIR)/lib/version.txt
-    AUTO_ARDUINO_VERSION := $(shell [ -e $(VERSION_FILE) ] && cat $(VERSION_FILE) | sed -e 's/[.]//g' -e 's/$$/0000/' | head -c3)
+    AUTO_ARDUINO_VERSION := $(shell [ -e $(VERSION_FILE) ] && cat $(VERSION_FILE) | sed -e 's/^[0-9]://g' -e 's/[.]//g' -e 's/$$/0000/' | head -c3)
     ifdef AUTO_ARDUINO_VERSION
         ARDUINO_VERSION = $(AUTO_ARDUINO_VERSION)
         $(call show_config_variable,ARDUINO_VERSION,[AUTODETECTED])


### PR DESCRIPTION
Here's my fix (along with @matthijskooijman) for issue #65

Essentially it adds another sed pass to remove the 1: prefix from Debian version strings (starts with any single number followed by a colon)

It works for me on Debian with 0.10-5 and IDE 1.0.5 e.g. "1:1.0.5+dfsg2-1" becomes "105", it won't break other version detection, e.g. "1.0.1" still becomes "101", "0023" becomes "002"

@matthijskooijman - i managed to clean my repo up, so this replaces [pull #67](https://github.com/sudar/Arduino-Makefile/pull/67)
