### PR TITLE
Serial monitor baud rate detection (fixes issue #52)

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -561,7 +561,7 @@ endif
 ifndef MONITOR_BAUDRATE
     # This works only in linux. TODO: Port it to MAC OS also
     # https://github.com/sudar/Arduino-Makefile/issues/52
-    SPEED = $(shell grep --max-count=1 --regexp="Serial.begin" $(LOCAL_PDE_SRCS) $(LOCAL_INO_SRCS) | sed -e 's/\t//g' -e 's/\/\/.*$$//g' -e 's/(/\t/' -e 's/)/\t/' | awk -F '\t' '{print $$2}' )
+    SPEED = $(shell egrep -h 'Serial.begin\([0-9]+\)' $(LOCAL_PDE_SRCS) $(LOCAL_INO_SRCS) | sed -e 's/[^0-9]//g'| head -n1)
     MONITOR_BAUDRATE = $(findstring $(SPEED),300 1200 2400 4800 9600 14400 19200 28800 38400 57600 115200)
 
     ifeq ($(MONITOR_BAUDRATE),)


### PR DESCRIPTION
new regex tested on debian jessie and mountain lion

fixes issue [#52](https://github.com/sudar/Arduino-Makefile/issues/52)

produces this when I use Serial.begin(9600); 

```
- [DETECTED]           MONITOR_BAUDRATE = 9600  (in sketch)
```
