### PR TITLE
Fix directory creation for library source files

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -706,16 +706,20 @@ $(call show_separator)
 # easy to change the build options in future
 
 # library sources
-$(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.c | $(OBJDIR)
+$(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.c
+	mkdir -p $(dir $@)
 	$(CC) -MMD -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
-$(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.cpp | $(OBJDIR)
+$(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.cpp
+	mkdir -p $(dir $@)
 	$(CC) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
-$(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.cpp | $(OBJDIR)
+$(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.cpp
+	mkdir -p $(dir $@)
 	$(CC) -MMD -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
-$(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.c | $(OBJDIR)
+$(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.c
+	mkdir -p $(dir $@)
 	$(CC) -MMD -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
 ifdef COMMON_DEPS


### PR DESCRIPTION
In commit 3bce1d88 (Allow adding extra common dependencies), the way
$(OBJDIR) was created changed. Instead of having some ad-hoc mkdir calls
around, all relevant rules were made to depend on the directory instead.

However, this change didn't take into account that the object files for
libraries live instead a subdirectory of $(OBJDIR), which was no longer
automatically created. This made compilation of all libraries fail, on a
clean build directory.

Fixing the rules to depend on $(dir $@) or $(dir %) doesn't work, since
those function calls are expanded by making upon reading the file, not
later when the rule is actually matched.

Therefore, this commit restores the previous explicit mkdir calls for
library object files. The non-library objects files, which do not live
in a subdirectory, still use the dependency approach as before.

Fixes: #58
