### PR TITLE
Don't indent variable assignments with tabs

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -721,9 +721,9 @@ $(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.c
 	$(CC) -MMD -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
 ifdef COMMON_DEPS
-	COMMON_DEPS := $(COMMON_DEPS) Makefile
+    COMMON_DEPS := $(COMMON_DEPS) Makefile
 else
-	COMMON_DEPS := Makefile
+    COMMON_DEPS := Makefile
 endif
 
 # normal local sources


### PR DESCRIPTION
This causes make to consider the line part of the preceding recipe,
causing the variable to remain unset and the preceding recipe to break.
In this case, this was the recipe for user libraries with .c files,
which is uncommon enough for this to go unnoticed.
