### PR TITLE
Added Micro to the Leonardo reset functions

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -380,8 +380,16 @@ endif
 ########################################################################
 # Reset
 #
+ifeq ($(BOARD_TAG),leonardo)
+    LEO_RESET = 1
+endif
+
+ifeq ($(BOARD_TAG),micro)
+    LEO_RESET = 1
+endif
+
 ifndef RESET_CMD
-    ifeq ($(BOARD_TAG),leonardo)
+    ifdef LEO_RESET
        RESET_CMD = $(ARDMK_PATH)/ard-reset-arduino --leonardo \
           $(ARD_RESET_OPTS) $(call get_arduino_port)
     else
@@ -391,7 +399,7 @@ ifndef RESET_CMD
 endif
 
 ifndef WAIT_CONNECTION_CMD
-    ifeq ($(BOARD_TAG),leonardo)
+    ifdef LEO_RESET
        WAIT_CONNECTION_CMD = \
          $(ARDMK_PATH)/wait-connection-leonardo $(call get_arduino_port)
     else

--- a/bin/ard-reset-arduino
+++ b/bin/ard-reset-arduino
@@ -99,7 +99,7 @@ Specify the DTR pulse width in seconds.
 
 =item --leonardo
 
-Reset a Leonardo.
+Reset a Leonardo or Micro.
 
 =back
 
@@ -115,7 +115,7 @@ Patches are welcome.
 
 Martin Oldfield, ex-atelier@mjo.tc
 
-Support for Leonardo added by sej7278, https://github.com/sej7278
+Support for Leonardo/Micro added by sej7278, https://github.com/sej7278
 
 Thanks to Daniele Vergini who suggested this to me, and supplied
 a command line version.


### PR DESCRIPTION
Fixes issue [#80](https://github.com/sudar/Arduino-Makefile/issues/80) although not 100% reliable (like Leo) after the port has been in use. See comments on issue [#30](https://github.com/sudar/Arduino-Makefile/issues/30)
