### PR TITLE
Search for and include file with local modifications

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -196,6 +196,18 @@
 #
 ########################################################################
 
+
+########################################################################
+#
+# include local configuration if it  exists
+MYDIR := $(dir $(lastword $(MAKEFILE_LIST)))
+ifneq ($(wildcard $(MYDIR)/Arduino.mk.local),) 
+include $(MYDIR)/Arduino.mk.local
+endif
+
+
+
+
 # Useful functions
 # Returns the first argument (typically a directory), if the file or directory
 # named by concatenating the first and optionally second argument


### PR DESCRIPTION
If you don't want to clobber your environment, don't want to mess with
the upstream makefile and dont want to tweak every project makefile, you
can now place an Arduino.mk.local file with your settings into the same
directory as Arduino.mk. If this new file exists, it will be included.

Signed-off-by: Ralf Doering ralf@rdoering.net
