### PR TITLE
Remove tab from empty line.

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -1047,7 +1047,7 @@ generate_assembly: $(OBJDIR)/$(TARGET).s
 
 generated_assembly: generate_assembly
 	@$(ECHO) "generated_assembly" target is deprecated. Use "generate_assembly" target instead
-	
+
 .PHONY:	all upload raw_upload raw_eeprom error_on_leonardo reset reset_stty ispload clean depends size show_boards monitor disasm symbol_sizes generated_assembly generate_assembly verify_size
 
 # added - in the beginning, so that we don't get an error if the file is not present


### PR DESCRIPTION
If editing and saving Arduino.mk with emacs, emacs complains about
"Suspicious line 1050". This line is empty but contains an extra tab.

Signed-off-by: Ralf Doering ralf@rdoering.net
