### PR TITLE
use MAKEFILE_LIST to get the name of the top make file

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -877,10 +877,11 @@ $(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.c
 	@$(MKDIR) $(dir $@)
 	$(CC) -MMD -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
+USER_MAKEFILE := $(firstword $(MAKEFILE_LIST))
 ifdef COMMON_DEPS
-    COMMON_DEPS := $(COMMON_DEPS) Makefile
+    COMMON_DEPS := $(COMMON_DEPS) $(USER_MAKEFILE)
 else
-    COMMON_DEPS := Makefile
+    COMMON_DEPS := $(USER_MAKEFILE)
 endif
 
 # normal local sources


### PR DESCRIPTION
While using Arduino-Makefile, I had some trouble getting it to work because my make file was called 'makefile'. This commit uses MAKEFILE_LIST to get the name of the top make file so it will work with any capitalization.
