### PR TITLE
Fixed ChipKIT paths for avrdude

### DIFF
--- a/arduino-mk/chipKIT.mk
+++ b/arduino-mk/chipKIT.mk
@@ -72,9 +72,9 @@ endif
 
 AVR_TOOLS_DIR = $(ARDUINO_DIR)/hardware/pic32/compiler/pic32-tools
 
-AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools
-AVRDUDE = $(AVRDUDE_DIR)/avrdude
-AVRDUDE_CONF = $(AVRDUDE_DIR)/avrdude.conf
+AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools/avr
+AVRDUDE = $(AVRDUDE_DIR)/bin/avrdude
+AVRDUDE_CONF = $(AVRDUDE_DIR)/etc/avrdude.conf
 
 ALTERNATE_CORE = pic32
 ALTERNATE_CORE_PATH = $(MPIDE_DIR)/hardware/pic32


### PR DESCRIPTION
Hey - I was having some problems with the ChipKIT Makefile and had to update some paths in the template file. I'm using Mpide 0023-macosx-20120803. Not sure if these changes were needed because I'm using a different version of Mpdie than yourself. Thought I'd send you over my modifications none-the-less.

Hope this finds you well,
Colin
