### PR TITLE
Adjust path to avrdude/avrdude.conf for MPIDE in Linux.

### DIFF
--- a/arduino-mk/chipKIT.mk
+++ b/arduino-mk/chipKIT.mk
@@ -72,9 +72,17 @@ endif
 
 AVR_TOOLS_DIR = $(ARDUINO_DIR)/hardware/pic32/compiler/pic32-tools
 
-AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools
-AVRDUDE = $(AVRDUDE_DIR)/avrdude
-AVRDUDE_CONF = $(AVRDUDE_DIR)/avrdude.conf
+# The same as in Arduino, the Linux distribution contains avrdude and
+# avrdude.conf in a different location.
+ifeq ($(CURRENT_OS),LINUX)
+    AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools
+    AVRDUDE = $(AVRDUDE_DIR)/avrdude
+    AVRDUDE_CONF = $(AVRDUDE_DIR)/avrdude.conf
+else
+    AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools/avr
+    AVRDUDE = $(AVRDUDE_DIR)/bin/avrdude
+    AVRDUDE_CONF = $(AVRDUDE_DIR)/etc/avrdude.conf
+endif
 
 ALTERNATE_CORE = pic32
 ALTERNATE_CORE_PATH = $(MPIDE_DIR)/hardware/pic32


### PR DESCRIPTION
This expands #133  to keep the correct path for Linux, Windows and OS X. I've tested in all three with the latest MPIDE from chipkit.net/started. Flashing from Windows fails for other reasons, but it's at least able to find the avrdude binary and config.
