### PR TITLE
Add option to set fuses without burning a bootloader

### DIFF
--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -1143,6 +1143,14 @@ ifneq ($(strip $(AVRDUDE_ISP_FUSES_POST)),)
 		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) $(AVRDUDE_ISP_FUSES_POST)
 endif
 
+set_fuses:
+ifneq ($(strip $(AVRDUDE_ISP_FUSES_PRE)),)
+		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) -e $(AVRDUDE_ISP_FUSES_PRE)
+endif
+ifneq ($(strip $(AVRDUDE_ISP_FUSES_POST)),)
+		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) $(AVRDUDE_ISP_FUSES_POST)
+endif
+
 clean:
 		$(REMOVE) $(LOCAL_OBJS) $(CORE_OBJS) $(LIB_OBJS) $(CORE_LIB) $(TARGETS) $(DEPS) $(USER_LIB_OBJS) ${OBJDIR}
 
@@ -1193,7 +1201,8 @@ help:
                           the capacity of the micro controller.\n\
   make eeprom           - upload the eep file\n\
   make raw_eeprom       - upload the eep file without first resetting\n\
-  make burn_bootloader  - Burn bootloader and/or fuses\n\
+  make burn_bootloader  - burn bootloader and fuses\n\
+  make set_fuses        - set fuses without burning bootloader\n\
   make help             - show this help\n\
 "
 	@$(ECHO) "Please refer to $(ARDMK_FILE) for more details.\n"


### PR DESCRIPTION
When using ICSP programmers e.g. usbasp, you can burn sketches directly to the chip without having to burn a bootloader, however you do need to set fuses e.g. if you're changing speed/BOD.

This pull request adds `make set_fuses` to achieve this capability.

I've also updated the help text to include `make set_fuses` and also changed `make burn_bootloader` help text which wasn't entirely accurate (it said you can burn bootloader and/or fuses, whereas the "or" was not possible)

P.S. `make ispload` doesn't set the fuses anymore.
