### PR TITLE
Allow target specific optimization levels/debug flags

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Don't append port details to avrdude for usbtiny. Fix #140 and #138 (https://github.com/PPvG)
 - Fix: Handle relative paths of bootloader file while burning bootloaders. Fix #126 and #142 (https://github.com/sej7278)
 - New: Add `CONTRIBUTING.md` explaining how to contribute to the project.
+- Force -Os optimization for SoftwareSerial. Add `OPTIMIZATION_FLAGS` and `DEBUG_FLAGS`.
 
 ### 1.0.1 (2013-09-25)
 - Unconditionally add -D in avrdude options. See #114

--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -780,6 +780,13 @@ else
     $(call show_config_variable,OPTIMIZATION_LEVEL,[USER])
 endif
 
+ifndef DEBUG_FLAGS
+    DEBUG_FLAGS = -O0 -g
+endif
+
+# SoftwareSerial requires -Os (some delays are tuned for this optimization level)
+%SoftwareSerial.o : OPTIMIZATION_FLAGS = -Os
+
 ifndef MCU_FLAG_NAME
     MCU_FLAG_NAME = mmcu
     $(call show_config_variable,MCU_FLAG_NAME,[DEFAULT])
@@ -794,10 +801,12 @@ CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_V
         -fdata-sections
 
 ifdef DEBUG
-CPPFLAGS += -O0 -g
+OPTIMIZATION_FLAGS= $(DEBUG_FLAGS)
 else
-CPPFLAGS += -O$(OPTIMIZATION_LEVEL)
+OPTIMIZATION_FLAGS = -O$(OPTIMIZATION_LEVEL)
 endif
+
+CPPFLAGS += $(OPTIMIZATION_FLAGS)
 
 # USB IDs for the Caterina devices like leonardo or micro
 ifneq ($(CATERINA),)


### PR DESCRIPTION
Changing the optimization level from -Os to something else breaks the
SoftwareSerial library. This patch allow to set optimization flags on a
per target basis.
