### PR TITLE
Debian package rebuild instructions.

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -4,16 +4,16 @@ Use these instructions to build your own Deb package from your local sources.
 For the latest official packages go to [Debian](http://packages.debian.org/arduino-mk)
 or [Ubuntu](https://launchpad.net/ubuntu/+source/arduino-mk) or use apt.
 
-First install the dependencies as root:
+First install the dependencies for building/running the package, as root:
 
     apt-get build-dep arduino-mk
-    apt-get install arduino-core libdevice-serialport-perl help2man build-essential dpkg-dev
+    apt-get install arduino-core libdevice-serialport-perl help2man build-essential dpkg-dev fakeroot perl-doc devscripts
 
 Fetch the Debian source:
 
     apt-get source arduino-mk
 
-Make any local changes to want within arduino-mk-* directory and update the package version:
+Make any local changes to want within the arduino-mk-* directory and update the package version:
 
     cd arduino-mk-*
     dch -i


### PR DESCRIPTION
As we're keeping the debian/ directory upstream, I thought we should have a way for users to make their own Debian packages from their local changes.

Also has instructions for getting official upstream builds for their distro (Debian/Ubuntu).

Could even be used as a basis for making packages for unsupported distro's such as Raspbian.
