### PR TITLE
2nd attempt at fixing #147 - keeps Common.mk

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ A Makefile for Arduino Sketches
 The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
+### 1.2.0 (2014-01-12)
+- Fixes #147
+
 ### 1.1.0 (2013-12-26)
 - Don't append port details to avrdude for usbasp. See #123
 - Ignore commented lines while parsing boards.txt file. See #124

--- a/README.md
+++ b/README.md
@@ -15,17 +15,13 @@ On the Mac you might want to set:
     ARDUINO_DIR   = /Applications/Arduino.app/Contents/Resources/Java
     ARDMK_DIR     = /usr/local
 
-On Linux, you might prefer:
+On Linux, you shouldn't need to set anything other than your board type and port:
 
-    ARDUINO_DIR   = /usr/share/arduino
-    ARDMK_DIR     = /usr/share/arduino
-    ARDMK_PATH    = /usr/bin
-    AVR_TOOLS_DIR = /usr
+    BOARD_TAG    = mega2560
+    MONITOR_PORT = /dev/ttyACM0
 
-- `ARDUINO_DIR` - Path to Arduino installation
-- `ARDMK_DIR`   - Path where the `*.mk` are present. If you installed the package, then it is usually `/usr/share/arduino`
-- `ARDMK_PATH`  - Path where the `ard-reset-arduino` script is present. If you installed the package, then it is usually `/usr/bin`
-- `AVR_TOOLS_DIR` - Path where the avr tools chain binaries are present. If you are going to use the binaries that came with Arduino installation, then you don't have to set it.
+- `BOARD_TAG` - Type of board, for a list see boards.txt or `make show_boards`
+- `MONITOR_PORT` - The port where your Arduino is plugged in, usually `/dev/ttyACM0` or `/dev/ttyUSB0`
 
 The Makefile also delegates resetting the board to a short Perl program.
 You'll need to install `Device::SerialPort` to use it though.
@@ -80,7 +76,7 @@ It is possible to use [`colorgcc`](https://github.com/colorgcc/colorgcc) with th
 
 ## Versioning
 
-The current version of the makefile is `1.1.0`. You can find the full history in the [HISTORY.md](HISTORY.md) file
+The current version of the makefile is `1.2.0`. You can find the full history in the [HISTORY.md](HISTORY.md) file
 
 This project adheres to Semantic [Versioning 2.0](http://semver.org/).
 
@@ -92,7 +88,7 @@ published by the Free Software Foundation; either version 2.1 of the License, or
 
 ## Contribution
 
-All contributions (even documentation) are welcome :) Open a pull request and I would be happy to merge them. 
+All contributions (even documentation) are welcome :) Open a pull request and I would be happy to merge them.
 Also checkout the [contribution guide](CONTRIBUTING.md) for more details.
 
 If you are looking for ideas to work on, then check out the following TODO items or the [issue tracker](https://github.com/sudar/Arduino-Makefile/issues/).
@@ -108,7 +104,7 @@ If you find an issue or have an idea for a feature then log them in the [issue t
 
 ## Credits
 
-This makefile was originally created by [Martin Oldfield](http://mjo.tc/atelier/2009/02/arduino-cli.html) and he maintained it till v0.10.2. 
+This makefile was originally created by [Martin Oldfield](http://mjo.tc/atelier/2009/02/arduino-cli.html) and he maintained it till v0.10.2.
 From May 2013, it is maintained by [Sudar](http://hardwarefun.com/tutorials/compiling-arduino-sketches-using-makefile)
 
 ## Similar works

--- a/arduino-mk/Arduino.mk
+++ b/arduino-mk/Arduino.mk
@@ -19,7 +19,7 @@
 #
 # Original Arduino adaptation by mellis, eighthave, oli.keller
 #
-# Current version: 1.1.0
+# Current version: 1.2.0
 #
 # Refer to HISTORY.md file for complete history of changes
 #
@@ -29,9 +29,8 @@
 #
 # We need to worry about three different sorts of file:
 #
-# 1. Things which are included in this distribution e.g. ard-reset-arduino
-#    => ARDMK_DIR - Where the *.mk files are stored
-#    => ARDMK_PATH - Where the ard-reset-arduino script is stored
+# 1. The directory where the *.mk files are stored
+#    => ARDMK_DIR
 #
 # 2. Things which are always in the Arduino distribution e.g.
 #    boards.txt, libraries, &c.
@@ -54,18 +53,13 @@
 # On Linux, you might prefer:
 #
 #   ARDUINO_DIR   = /usr/share/arduino
-#   ARDMK_DIR     = /usr
-#   AVR_TOOLS_DIR = /usr
+#   ARDMK_DIR     = /usr/share/arduino
 #
 # You can either set these up in the Makefile, or put them in your
 # environment e.g. in your .bashrc
 #
 # If you don't specify these, we can try to guess, but that might not work
 # or work the way you want it to.
-#
-# If you don't install the ard-reset-arduino binary to /usr/local/bin, but
-# instead copy them to e.g. /home/mjo/arduino.mk/bin then set
-#   ARDMK_PATH = /home/mjo/arduino.mk/bin
 #
 # If you'd rather not see the configuration output, define ARDUINO_QUIET.
 #
@@ -112,8 +106,8 @@
 # submodule (or other similar arrangement), you might have lines like this
 # in your Makefile:
 #
-#        ARDMK_DIR := $(realpath ../../tools/Arduino-Makefile)
-#        include $(ARDMK_DIR)/arduino-mk/Arduino.mk
+#        ARDMK_DIR := $(realpath ../../tools/Arduino-Makefile/arduino-mk)
+#        include $(ARDMK_DIR)/Arduino.mk
 #
 # In any case, once this file has been created the typical workflow is just
 #
@@ -231,38 +225,21 @@ endif
 # Makefile distribution path
 
 ifndef ARDMK_DIR
-    # presume it's a level above the path to our own file
-    ARDMK_DIR := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST))))/..)
+    # presume it's the same path to our own file
+    ARDMK_DIR := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 else
-    # show_config_variable macro is defined in Common.mk file and is not available yet. 
+    # show_config_variable macro is defined in Common.mk file and is not available yet.
     # Let's define a variable to know that user specified ARDMK_DIR
     ARDMK_DIR_MSG = USER
 endif
 
-ifneq ($(wildcard $(ARDMK_DIR)/arduino-mk/Common.mk),)
-    # git checkout
-    ARDMK_FILE = $(ARDMK_DIR)/arduino-mk/arduino.mk
-    include $(ARDMK_DIR)/arduino-mk/Common.mk
-else
-    ifneq ($(wildcard $(ARDMK_DIR)/Common.mk),)
-        # package install
-        ARDMK_FILE = $(ARDMK_DIR)/arduino.mk
-        include $(ARDMK_DIR)/Common.mk
-    endif
-endif
+include $(ARDMK_DIR)/Common.mk
 
 # show_config_variable macro is available now. So let's print config details for ARDMK_DIR
 ifndef ARDMK_DIR_MSG
     $(call show_config_variable,ARDMK_DIR,[COMPUTED],(relative to $(notdir $(lastword $(MAKEFILE_LIST)))))
 else
     $(call show_config_variable,ARDMK_DIR,[USER])
-endif
-
-ifndef ARDMK_PATH
-    ARDMK_PATH = $(ARDMK_DIR)/bin
-    $(call show_config_variable,ARDMK_PATH,[COMPUTED],(relative to ARDMK_DIR))
-else
-    $(call show_config_variable,ARDMK_PATH,[USER])
 endif
 
 ########################################################################
@@ -590,12 +567,19 @@ endif
 ########################################################################
 # Reset
 
+ARD_RESET_ARDUINO := $(shell which ard-reset-arduino)
+ifndef ARD_RESET_ARDUINO
+	# one level up from *.mk in bin directory when checked out from git
+	# or in $PATH when packaged
+	ARD_RESET_ARDUINO = $(ARDMK_DIR)/../bin/ard-reset-arduino
+endif
+
 ifndef RESET_CMD
     ifneq ($(CATERINA),)
-       RESET_CMD = $(ARDMK_PATH)/ard-reset-arduino --caterina \
+       RESET_CMD = $(ARD_RESET_ARDUINO) --caterina \
           $(ARD_RESET_OPTS) $(call get_monitor_port)
     else
-       RESET_CMD = $(ARDMK_PATH)/ard-reset-arduino \
+       RESET_CMD = $(ARD_RESET_ARDUINO) \
           $(ARD_RESET_OPTS) $(call get_monitor_port)
     endif
 endif
@@ -995,7 +979,7 @@ endif
 # Default avrdude options
 # -V Do not verify
 # -q - suppress progress output
-# -D - Disable auto erase for flash memory 
+# -D - Disable auto erase for flash memory
 # (-D is needed for Mega boards. See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
 ifndef AVRDUDE_OPTS
     AVRDUDE_OPTS = -q -V -D
@@ -1221,7 +1205,7 @@ help:
   make set_fuses        - set fuses without burning bootloader\n\
   make help             - show this help\n\
 "
-	@$(ECHO) "Please refer to $(ARDMK_FILE) for more details.\n"
+	@$(ECHO) "Please refer to Arduino.mk for more details.\n"
 
 .PHONY: all upload raw_upload raw_eeprom error_on_caterina reset reset_stty ispload \
         clean depends size show_boards monitor disasm symbol_sizes generated_assembly \

--- a/arduino-mk/chipKIT.mk
+++ b/arduino-mk/chipKIT.mk
@@ -27,23 +27,12 @@
 # The show_config_variable is unavailable before we include the common makefile,
 # so we defer logging the ARDMK_DIR info until it happens in Arduino.mk
 ifndef ARDMK_DIR
-    # presume it's a level above the path to our own file
-    ARDMK_DIR := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST))))/..)
+    # presume it's the same path to our own file
+    ARDMK_DIR := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 endif
 
-ifndef ARDMK_PATH
-    ARDMK_PATH = $(ARDMK_DIR)/bin
-endif
-
-ifneq ($(wildcard $(ARDMK_DIR)/arduino-mk/Common.mk),)
-    # git checkout
-    include $(ARDMK_DIR)/arduino-mk/Common.mk
-else
-    ifneq ($(wildcard $(ARDMK_DIR)/Common.mk),) 
-        # package install
-        include $(ARDMK_DIR)/Common.mk
-    endif
-endif
+include $(ARDMK_DIR)/Common.mk
+include $(ARDMK_DIR)/Arduino.mk
 
 ifndef MPIDE_DIR
     AUTO_MPIDE_DIR := $(firstword \
@@ -68,7 +57,6 @@ ifndef MPIDE_PREFERENCES_PATH
        $(call show_config_variable,MPIDE_PREFERENCES_PATH,[autodetected])
     endif
 endif
-
 
 AVR_TOOLS_DIR = $(ARDUINO_DIR)/hardware/pic32/compiler/pic32-tools
 
@@ -109,5 +97,3 @@ LDFLAGS  += -T$(ARDUINO_CORE_PATH)/$(LDSCRIPT)
 LDFLAGS  += -T$(ARDUINO_CORE_PATH)/chipKIT-application-COMMON.ld
 CPPFLAGS += -mno-smart-io -fno-short-double
 CFLAGS_STD =
-
-include $(ARDMK_DIR)/arduino-mk/Arduino.mk

--- a/packaging/fedora/README.md
+++ b/packaging/fedora/README.md
@@ -6,7 +6,7 @@ First install the dependencies as root:
 
 From the top-level Arduino-Makefile directory you've checked out of github, run the following (as unprivileged user) to create a compressed tarball using the naming conventions required by rpmbuild:
 
-    git archive --prefix=arduino-mk-1.1.0/ --format=tar -o ../arduino-mk-1.1.0.tar.gz -v HEAD | gzip
+    git archive HEAD --prefix=arduino-mk-1.2.0/ -o ../arduino-mk-1.2.0.tar.gz
 
 If you don't already have a rpmbuild setup (e.g. you've not installed the SRPM) you will need to create the directories:
 
@@ -14,7 +14,7 @@ If you don't already have a rpmbuild setup (e.g. you've not installed the SRPM) 
 
 Then copy the tarball and specfile into those directories:
 
-    cp ../arduino-mk-1.1.0.tar.gz ~/rpmbuild/SOURCES/
+    cp ../arduino-mk-1.2.0.tar.gz ~/rpmbuild/SOURCES/
     cp packaging/fedora/arduino-mk.spec ~/rpmbuild/SPECS/
 
 Then compile. This will create a binary and source RPM:

--- a/packaging/fedora/arduino-mk.spec
+++ b/packaging/fedora/arduino-mk.spec
@@ -1,5 +1,5 @@
 Name:			arduino-mk
-Version:		1.1.0
+Version:		1.2.0
 Release:		1%{dist}
 Summary:		Program your Arduino from the command line
 Packager:		Simon John <git@the-jedi.co.uk>
@@ -51,5 +51,7 @@ rm -rf %{buildroot}
 %{_docdir}/%{name}/examples
 
 %changelog
+* Sun Jan 12 2014 Simon John <git@the-jedi.co.uk>
+- Updated release.
 * Mon Dec 30 2013 Simon John <git@the-jedi.co.uk>
 - Initial release.


### PR DESCRIPTION
may be preferable to pull request #149

updated version to 1.2.0

removed ARDMK_PATH - tries to autodetect path to ard-reset-arduino

removed ARDMK_FILE - so no need to fix case of arduino.mk/Arduino.mk

removed some trailing whitespace

removed need to workaround arduino-mk subdirectory

fixed git archive syntax in RPM instructions

updated docs to reflect changes
