### PR TITLE
Use more reliable serial device naming in Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ On Linux, you shouldn't need to set anything other than your board type and port
     MONITOR_PORT = /dev/ttyACM0
 
 - `BOARD_TAG` - Type of board, for a list see boards.txt or `make show_boards`
-- `MONITOR_PORT` - The port where your Arduino is plugged in, usually `/dev/ttyACM0` or `/dev/ttyUSB0`
+- `MONITOR_PORT` - The port where your Arduino is plugged in, usually `/dev/ttyACM0` or `/dev/ttyUSB0` in Linux or Mac OS X and `com3`, `com4`, etc. in Windows.
 - `ARDUINO_DIR` - Path to Arduino installation
 - `ARDMK_DIR`   - Path where the `*.mk` are present. If you installed the package, then it is usually `/usr/share/arduino`
 - `AVR_TOOLS_DIR` - Path where the avr tools chain binaries are present. If you are going to use the binaries that came with Arduino installation, then you don't have to set it.


### PR DESCRIPTION
- Strip leading "/dev/" from MONITOR_PORT before handing to avrdude in Windows.
- Use the more widely available awk tool instead of bc to subtract 1
  from COM ID (as opposed to `bc`).
- Allow Windows user to specify "com1" or just "1".
- Document MONITOR_PORT format for Windows users.

This fixes #139 for me.
