### PR TITLE
Don't hard code MONITOR_PORT in examples, for more flexible testing.

### DIFF
--- a/examples/AnalogInOutSerial/Makefile
+++ b/examples/AnalogInOutSerial/Makefile
@@ -1,5 +1,4 @@
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
-ARDUINO_LIBS = 
+ARDUINO_LIBS =
 
 include ../../Arduino.mk

--- a/examples/Blink/Makefile
+++ b/examples/Blink/Makefile
@@ -1,6 +1,5 @@
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
-ARDUINO_LIBS = 
+ARDUINO_LIBS =
 
 include ../../Arduino.mk
 

--- a/examples/BlinkChipKIT/Makefile
+++ b/examples/BlinkChipKIT/Makefile
@@ -1,5 +1,4 @@
 BOARD_TAG    = mega_pic32
-MONITOR_PORT = /dev/cu.usb*
 ARDUINO_LIBS =
 
 include ../../chipKIT.mk

--- a/examples/BlinkInAVRC/Makefile
+++ b/examples/BlinkInAVRC/Makefile
@@ -10,7 +10,6 @@ F_CPU = 8000000L
 
 ISP_PROG   = stk500v1
 AVRDUDE_ISP_BAUDRATE = 19200
-ISP_PORT = /dev/ttyACM*
 
 include $(ARDMK_DIR)/Arduino.mk
 

--- a/examples/BlinkWithoutDelay/Makefile
+++ b/examples/BlinkWithoutDelay/Makefile
@@ -1,5 +1,4 @@
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
-ARDUINO_LIBS = 
+ARDUINO_LIBS =
 
 include ../../Arduino.mk

--- a/examples/Fade/Makefile
+++ b/examples/Fade/Makefile
@@ -1,5 +1,4 @@
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
-ARDUINO_LIBS = 
+ARDUINO_LIBS =
 
 include ../../Arduino.mk

--- a/examples/HelloWorld/Makefile
+++ b/examples/HelloWorld/Makefile
@@ -1,5 +1,4 @@
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
 ARDUINO_LIBS = LiquidCrystal
 
 include ../../Arduino.mk

--- a/examples/TinySoftWareSerial/Makefile
+++ b/examples/TinySoftWareSerial/Makefile
@@ -1,12 +1,11 @@
 # Arduino Make file. Refer to https://github.com/sudar/Arduino-Makefile
 
-# if you have placed the alternate core in your sketchbook directory, then you can just mention the core name alone. 
+# if you have placed the alternate core in your sketchbook directory, then you can just mention the core name alone.
 ALTERNATE_CORE = attiny
 # If not, you might have to include the full path.
 #ALTERNATE_CORE_PATH = /home/sudar/Dropbox/code/arduino-sketches/hardware/attiny/
 
 BOARD_TAG    = attiny85-8
-ISP_PORT = /dev/ttyACM*
 
 ARDUINO_LIBS = SoftwareSerial
 

--- a/examples/WebServer/Makefile
+++ b/examples/WebServer/Makefile
@@ -1,7 +1,6 @@
 # Arduino Make file. Refer to https://github.com/sudar/Arduino-Makefile
 
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
 ARDUINO_LIBS = Ethernet SPI
 
 include ../../Arduino.mk

--- a/examples/master_reader/Makefile
+++ b/examples/master_reader/Makefile
@@ -1,7 +1,6 @@
 # Arduino Make file. Refer to https://github.com/sudar/Arduino-Makefile
 
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
 ARDUINO_LIBS = Wire
 
 include ../../Arduino.mk

--- a/examples/toneMelody/Makefile
+++ b/examples/toneMelody/Makefile
@@ -1,5 +1,4 @@
 BOARD_TAG    = uno
-MONITOR_PORT = /dev/cu.usb*
-ARDUINO_LIBS = 
+ARDUINO_LIBS =
 
 include ../../Arduino.mk


### PR DESCRIPTION
I have to go in and delete the MONITOR_PORT line in the test Makefiles every time - this would be nice.
