### PR TITLE
Silence the stderr output from call to `which`.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -570,7 +570,7 @@ endif
 # Reset
 
 ifndef RESET_CMD
-	ARD_RESET_ARDUINO := $(shell which ard-reset-arduino)
+	ARD_RESET_ARDUINO := $(shell which ard-reset-arduino 2> /dev/null)
 	ifndef ARD_RESET_ARDUINO
 		# same level as *.mk in bin directory when checked out from git
 		# or in $PATH when packaged


### PR DESCRIPTION
If `ard-reset-arduino` cannot be found it's already going to be detected on line 574, so this just silences the error output from `which` so the user isn't bothered when it's not in their `PATH`.
