### PR TITLE
Override complete compiler tool paths for chipKIT.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -354,7 +354,8 @@ endif
 
 ifndef AVR_TOOLS_DIR
 
-    BUNDLED_AVR_TOOLS_DIR := $(call dir_if_exists,$(ARDUINO_DIR)/hardware/tools/avr)
+    BUNDLED_AVR_TOOLS_DIR ?= $(call dir_if_exists,$(ARDUINO_DIR)/hardware/tools/avr)
+
     ifdef BUNDLED_AVR_TOOLS_DIR
         AVR_TOOLS_DIR     = $(BUNDLED_AVR_TOOLS_DIR)
         $(call show_config_variable,AVR_TOOLS_DIR,[BUNDLED],(in Arduino distribution))
@@ -708,15 +709,20 @@ TARGET_EEP = $(OBJDIR)/$(TARGET).eep
 TARGETS    = $(OBJDIR)/$(TARGET).*
 CORE_LIB   = $(OBJDIR)/libcore.a
 
-# Names of executables
-CC      = $(AVR_TOOLS_PATH)/$(CC_NAME)
-CXX     = $(AVR_TOOLS_PATH)/$(CXX_NAME)
-AS      = $(AVR_TOOLS_PATH)/$(AS_NAME)
-OBJCOPY = $(AVR_TOOLS_PATH)/$(OBJCOPY_NAME)
-OBJDUMP = $(AVR_TOOLS_PATH)/$(OBJDUMP_NAME)
-AR      = $(AVR_TOOLS_PATH)/$(AR_NAME)
-SIZE    = $(AVR_TOOLS_PATH)/$(SIZE_NAME)
-NM      = $(AVR_TOOLS_PATH)/$(NM_NAME)
+# Names of executables - chipKIT needs to override all to set paths to PIC32
+# tools, and we can't use "?=" assignment because these are already implicitly
+# defined by Make (e.g. $(CC) == cc).
+ifndef OVERRIDE_EXECUTABLES
+    CC      = $(AVR_TOOLS_PATH)/$(CC_NAME)
+    CXX     = $(AVR_TOOLS_PATH)/$(CXX_NAME)
+    AS      = $(AVR_TOOLS_PATH)/$(AS_NAME)
+    OBJCOPY = $(AVR_TOOLS_PATH)/$(OBJCOPY_NAME)
+    OBJDUMP = $(AVR_TOOLS_PATH)/$(OBJDUMP_NAME)
+    AR      = $(AVR_TOOLS_PATH)/$(AR_NAME)
+    SIZE    = $(AVR_TOOLS_PATH)/$(SIZE_NAME)
+    NM      = $(AVR_TOOLS_PATH)/$(NM_NAME)
+endif
+
 REMOVE  = rm -rf
 MV      = mv -f
 CAT     = cat

--- a/chipKIT.mk
+++ b/chipKIT.mk
@@ -57,20 +57,12 @@ ifndef MPIDE_PREFERENCES_PATH
     endif
 endif
 
-
-AVR_TOOLS_DIR = $(ARDUINO_DIR)/hardware/pic32/compiler/pic32-tools
-
-# The same as in Arduino, the Linux distribution contains avrdude and
-# avrdude.conf in a different location.
 ifeq ($(CURRENT_OS),LINUX)
-    AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools
-    AVRDUDE = $(AVRDUDE_DIR)/avrdude
-    AVRDUDE_CONF = $(AVRDUDE_DIR)/avrdude.conf
-else
-    AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools/avr
-    AVRDUDE = $(AVRDUDE_DIR)/bin/avrdude
-    AVRDUDE_CONF = $(AVRDUDE_DIR)/etc/avrdude.conf
+    BUNDLED_AVR_TOOLS_DIR = $(call dir_if_exists,$(MPIDE_DIR)/hardware/tools)
 endif
+
+PIC32_TOOLS_DIR = $(ARDUINO_DIR)/hardware/pic32/compiler/pic32-tools
+PIC32_TOOLS_PATH = $(PIC32_TOOLS_DIR)/bin
 
 ALTERNATE_CORE = pic32
 ALTERNATE_CORE_PATH = $(MPIDE_DIR)/hardware/pic32
@@ -88,6 +80,17 @@ AR_NAME = pic32-ar
 OBJDUMP_NAME = pic32-objdump
 OBJCOPY_NAME = pic32-objcopy
 SIZE_NAME = pic32-size
+NM_NAME = pic32-nm
+
+OVERRIDE_EXECUTABLES = 1
+CC      = $(PIC32_TOOLS_PATH)/$(CC_NAME)
+CXX     = $(PIC32_TOOLS_PATH)/$(CXX_NAME)
+AS      = $(PIC32_TOOLS_PATH)/$(AS_NAME)
+OBJCOPY = $(PIC32_TOOLS_PATH)/$(OBJCOPY_NAME)
+OBJDUMP = $(PIC32_TOOLS_PATH)/$(OBJDUMP_NAME)
+AR      = $(PIC32_TOOLS_PATH)/$(AR_NAME)
+SIZE    = $(PIC32_TOOLS_PATH)/$(SIZE_NAME)
+NM      = $(PIC32_TOOLS_PATH)/$(NM_NAME)
 
 LDSCRIPT = $(call PARSE_BOARD,$(BOARD_TAG),ldscript)
 LDSCRIPT_FILE = $(ARDUINO_CORE_PATH)/$(LDSCRIPT)


### PR DESCRIPTION
Previously we were setting the AVR tools path to the PIC32 tools path because it
made grabbing the compiling tools easier. Consequently, it made finding the
avrdude path much harder, especially since the avrdude files are in different
locations in the Linux distributions of MPIDE and Arduino.

Instead, we set the AVR tools path to the _correct_ path (where _AVR_ dude
lives), and totally override the CC, CXX, etc. paths to point to their PIC32
equivalents.

Eventually this will probably get merged with whatever changes made to handle the multiple platforms supported by Arduino 1.5 (AVR and ARM). The flashing tool and compiling tools are conflated in the current release, but we may need to split it up going forward based on this example (i.e. the chipKIT uses pic32 tools but still uses avrdude to flash).
