### PR TITLE
BUNDLED_AVR_TOOLS_DIR is now set correctly

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -354,7 +354,7 @@ endif
 
 ifndef AVR_TOOLS_DIR
 
-    BUNDLED_AVR_TOOLS_DIR ?= $(call dir_if_exists,$(ARDUINO_DIR)/hardware/tools/avr)
+    BUNDLED_AVR_TOOLS_DIR := $(call dir_if_exists,$(ARDUINO_DIR)/hardware/tools/avr)
 
     ifdef BUNDLED_AVR_TOOLS_DIR
         AVR_TOOLS_DIR     = $(BUNDLED_AVR_TOOLS_DIR)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ A Makefile for Arduino Sketches
 The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
+### 1.3.1 (2014-02-01)
+- Fix: BUNDLED_AVR_TOOLS_DIR is now set properly when using only arduino-core and not the whole arduino package. (https://github.com/sej7278)
+
 ### 1.3.0 (2014-01-29)
 - Fix: Use more reliable serial device naming in Windows. Fix issue #139 and #155 (https://github.com/peplin)
 - Fix: Document that ARDUINO_DIR must be a relative path in Windows. Fix issue #156 (https://github.com/peplin)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ It is possible to use [`colorgcc`](https://github.com/colorgcc/colorgcc) with th
 
 ## Versioning
 
-The current version of the makefile is `1.3.0`. You can find the full history in the [HISTORY.md](HISTORY.md) file
+The current version of the makefile is `1.3.1`. You can find the full history in the [HISTORY.md](HISTORY.md) file
 
 This project adheres to Semantic [Versioning 2.0](http://semver.org/).
 

--- a/packaging/fedora/README.md
+++ b/packaging/fedora/README.md
@@ -6,7 +6,7 @@ First install the dependencies as root:
 
 From the top-level Arduino-Makefile directory you've checked out of github, run the following (as unprivileged user) to create a compressed tarball using the naming conventions required by rpmbuild:
 
-    git archive HEAD --prefix=arduino-mk-1.3.0/ -o ../arduino-mk-1.3.0.tar.gz
+    git archive HEAD --prefix=arduino-mk-1.3.1/ -o ../arduino-mk-1.3.1.tar.gz
 
 If you don't already have a rpmbuild setup (e.g. you've not installed the SRPM) you will need to create the directories:
 
@@ -14,7 +14,7 @@ If you don't already have a rpmbuild setup (e.g. you've not installed the SRPM) 
 
 Then copy the tarball and specfile into those directories:
 
-    cp ../arduino-mk-1.3.0.tar.gz ~/rpmbuild/SOURCES/
+    cp ../arduino-mk-1.3.1.tar.gz ~/rpmbuild/SOURCES/
     cp packaging/fedora/arduino-mk.spec ~/rpmbuild/SPECS/
 
 Then compile. This will create a binary and source RPM:

--- a/packaging/fedora/arduino-mk.spec
+++ b/packaging/fedora/arduino-mk.spec
@@ -1,5 +1,5 @@
 Name:			arduino-mk
-Version:		1.3.0
+Version:		1.3.1
 Release:		1%{dist}
 Summary:		Program your Arduino from the command line
 Packager:		Simon John <git@the-jedi.co.uk>
@@ -51,6 +51,8 @@ rm -rf %{buildroot}
 %{_docdir}/%{name}/examples
 
 %changelog
+* Sat Feb 01 2014 Simon John <git@the-jedi.co.uk>
+- Updated version.
 * Mon Jan 13 2014 Simon John <git@the-jedi.co.uk>
 - Removed arduino-mk subdirectory
 * Mon Dec 30 2013 Simon John <git@the-jedi.co.uk>


### PR DESCRIPTION
BUNDLED_AVR_TOOLS_DIR is now set correctly using := instead of ?=, so that installations using only the arduino-core packages that don't have the $(ARDUINO_DIR)/hardware/tools/avr directory can still use the avr-g++ tools found in the $PATH (/usr/bin) without having to install the whole arduino IDE, e.g. raspberry pi.

Previously BUNDLED_AVR_TOOLS_DIR was set to an empty string (that's what ?= does for unset variables) as the directory doesn't exist, which meant that "ifdef BUNDLED_AVR_TOOLS_DIR..." was set to empty, rather than skipping to "else SYSTEMPATH_AVR_TOOLS_DIR...."

No user would set BUNDLED_AVR_TOOLS_DIR so the assignment operator := should be used not ?=

Updated the version info/changes in various locations.
