### PR TITLE
Added arduino-mk-vars.md to the RPM SPECfile.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ A Makefile for Arduino Sketches
 The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
+### 1.3.2 (in development)
+- Fix: Add arduino-mk-vars.md file to RPM SPECfile. (https://github.com/sej7278)
+
 ### 1.3.1 (2014-02-04)
 - Fix: BUNDLED_AVR_TOOLS_DIR is now set properly when using only arduino-core and not the whole arduino package. (https://github.com/sej7278)
 - New: Document all variables that can be overridden. (https://github.com/sej7278)

--- a/packaging/fedora/README.md
+++ b/packaging/fedora/README.md
@@ -6,7 +6,7 @@ First install the dependencies as root:
 
 From the top-level Arduino-Makefile directory you've checked out of github, run the following (as unprivileged user) to create a compressed tarball using the naming conventions required by rpmbuild:
 
-    git archive HEAD --prefix=arduino-mk-1.3.1/ -o ../arduino-mk-1.3.1.tar.gz
+    git archive HEAD --prefix=arduino-mk-1.3.2/ -o ../arduino-mk-1.3.2.tar.gz
 
 If you don't already have a rpmbuild setup (e.g. you've not installed the SRPM) you will need to create the directories:
 
@@ -14,10 +14,22 @@ If you don't already have a rpmbuild setup (e.g. you've not installed the SRPM) 
 
 Then copy the tarball and specfile into those directories:
 
-    cp ../arduino-mk-1.3.1.tar.gz ~/rpmbuild/SOURCES/
+    cp ../arduino-mk-1.3.2.tar.gz ~/rpmbuild/SOURCES/
     cp packaging/fedora/arduino-mk.spec ~/rpmbuild/SPECS/
 
 Then compile. This will create a binary and source RPM:
 
     cd ~/rpmbuild/SPECS/
     rpmbuild -ba arduino-mk.spec
+
+Fedora's AVR compilers use ccache, so you may have to override some of the paths to the AVR tools in your sketch's Makefile, for example:
+
+    OVERRIDE_EXECUTABLES = 1
+    CC                   = /usr/lib64/ccache/$(CC_NAME)
+    CXX                  = /usr/lib64/ccache/$(CXX_NAME)
+    AS                   = /usr/bin/$(AS_NAME)
+    OBJCOPY              = /usr/bin/$(OBJCOPY_NAME)
+    OBJDUMP              = /usr/bin/$(OBJDUMP_NAME)
+    AR                   = /usr/bin/$(AR_NAME)
+    SIZE                 = /usr/bin/$(SIZE_NAME)
+    NM                   = /usr/bin/$(NM_NAME)

--- a/packaging/fedora/arduino-mk.spec
+++ b/packaging/fedora/arduino-mk.spec
@@ -1,5 +1,5 @@
 Name:			arduino-mk
-Version:		1.3.1
+Version:		1.3.2
 Release:		1%{dist}
 Summary:		Program your Arduino from the command line
 Packager:		Simon John <git@the-jedi.co.uk>
@@ -33,7 +33,7 @@ install -m 755 -d %{buildroot}/%{_docdir}/%{name}
 install -m 755 -d %{buildroot}/%{_docdir}/%{name}/examples
 for dir in `find examples -type d` ; do install -m 755 -d %{buildroot}/%{_docdir}/%{name}/$dir ; done
 for file in `find examples -type f ! -name .gitignore` ; do install -m 644 $file %{buildroot}/%{_docdir}/%{name}/$file ; done
-install -m 644 *.mk %{buildroot}/%{_datadir}/arduino
+install -m 644 *.mk arduino-mk-vars.md %{buildroot}/%{_datadir}/arduino
 install -m 644 licence.txt %{buildroot}/%{_docdir}/%{name}
 install -m 755 bin/ard-reset-arduino %{buildroot}/%{_bindir}/ard-reset-arduino
 help2man %{buildroot}/%{_bindir}/ard-reset-arduino -n "Reset Arduino board" -s 1 -m "Arduino CLI Reset" --version-string=%{version} -N -o %{buildroot}/%{_mandir}/man1/ard-reset-arduino.1
@@ -46,11 +46,14 @@ rm -rf %{buildroot}
 %{_bindir}/ard-reset-arduino
 %{_mandir}/man1/ard-reset-arduino.1*
 %{_datadir}/arduino/*.mk
+%{_datadir}/arduino/arduino-mk-vars.md
 %doc %{_docdir}/%{name}/licence.txt
 %docdir %{_docdir}/%{name}/examples
 %{_docdir}/%{name}/examples
 
 %changelog
+* Tue Feb 04 2014 Simon John <git@the-jedi.co.uk>
+- Added arduino-mk-vars.md to the files to be installed/packaged.
 * Sat Feb 01 2014 Simon John <git@the-jedi.co.uk>
 - Updated version.
 * Mon Jan 13 2014 Simon John <git@the-jedi.co.uk>


### PR DESCRIPTION
Added some notes to the SPECfile regarding overriding the paths to the avr tools - most are in /usr/bin, but gcc/g++ are in an architecture-dependant ccache directory with symlinks.

Upped version to 1.3.2 devel
