### PR TITLE
now includes avr-libc/*.c files malloc.c and realloc.c

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -19,7 +19,7 @@
 #
 # Original Arduino adaptation by mellis, eighthave, oli.keller
 #
-# Current version: 1.3.1
+# Current version: 1.3.2
 #
 # Refer to HISTORY.md file for complete history of changes
 #
@@ -629,6 +629,7 @@ endif
 ifeq ($(strip $(NO_CORE)),)
     ifdef ARDUINO_CORE_PATH
         CORE_C_SRCS     = $(wildcard $(ARDUINO_CORE_PATH)/*.c)
+        CORE_C_SRCS    += $(wildcard $(ARDUINO_CORE_PATH)/avr-libc/*.c)
         CORE_CPP_SRCS   = $(wildcard $(ARDUINO_CORE_PATH)/*.cpp)
 
         ifneq ($(strip $(NO_CORE_MAIN_CPP)),)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 
 ### 1.3.2 (in development)
 - Fix: Add arduino-mk-vars.md file to RPM SPECfile. (https://github.com/sej7278)
+- Fix: Add avr-libc/malloc.c and realloc.c to included core files. Fixes issue #163 (https://github.com/sej7278)
 
 ### 1.3.1 (2014-02-04)
 - Fix: BUNDLED_AVR_TOOLS_DIR is now set properly when using only arduino-core and not the whole arduino package. (https://github.com/sej7278)


### PR DESCRIPTION
if bug-reporter confirms this fixes issue #163 then should be ok to merge.
