### PR TITLE
added "gpio" to the list of isp's that don't have a port

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1075,7 +1075,7 @@ endif
 
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
-ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny))
+ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio))
     AVRDUDE_ISP_OPTS += -P $(call get_isp_port)
 endif
 


### PR DESCRIPTION
the gpio programmer type is used on the raspberry pi to upload using the gpio spi pins via a sysfs interface, with a modified avrdude. its sort of kind of maybe a hardware isp, but doesn't have a device file like serial/usb.

partially fixes issue #165
