### PR TITLE
Fix AVR tools paths for chipKIT in Linux.

### DIFF
--- a/chipKIT.mk
+++ b/chipKIT.mk
@@ -57,8 +57,13 @@ ifndef MPIDE_PREFERENCES_PATH
     endif
 endif
 
+# The same as in Arduino, the Linux distribution contains avrdude and #
+# avrdude.conf in a different location, but for chipKIT it's even slightly
+# different than the Linux paths for Arduino, so we have to "double override".
 ifeq ($(CURRENT_OS),LINUX)
-    BUNDLED_AVR_TOOLS_DIR = $(call dir_if_exists,$(MPIDE_DIR)/hardware/tools)
+    AVRDUDE_DIR = $(ARDUINO_DIR)/hardware/tools
+    AVRDUDE = $(AVRDUDE_DIR)/avrdude
+    AVRDUDE_CONF = $(AVRDUDE_DIR)/avrdude.conf
 endif
 
 PIC32_TOOLS_DIR = $(ARDUINO_DIR)/hardware/pic32/compiler/pic32-tools


### PR DESCRIPTION
The paths aren't set correctly since 1893199dad.
