### PR TITLE
Fix: Consider usb... to be a valid ISP_PORT

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -836,7 +836,7 @@ endif
 get_monitor_port = $(if $(wildcard $(DEVICE_PATH)),$(firstword $(wildcard $(DEVICE_PATH))),$(error Arduino port $(DEVICE_PATH) not found!))
 
 # Returns the ISP port (first wildcard expansion) if it exists, otherwise it errors.
-get_isp_port = $(if $(wildcard $(ISP_PORT)),$(firstword $(wildcard $(ISP_PORT))),$(error ISP port $(ISP_PORT) not found!))
+get_isp_port = $(if $(wildcard $(ISP_PORT)),$(firstword $(wildcard $(ISP_PORT))),$(if $(findstring Xusb,X$(ISP_PORT)),$(ISP_PORT),$(error ISP port $(ISP_PORT) not found!)))
 
 # Command for avr_size: do $(call avr_size,elffile,hexfile)
 ifneq (,$(findstring AVR,$(shell $(SIZE) --help)))
@@ -1075,8 +1075,12 @@ endif
 
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
-ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio))
-    AVRDUDE_ISP_OPTS += -P $(call get_isp_port)
+ifndef $(ISP_PORT)
+    ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio))
+        AVRDUDE_ISP_OPTS += -P $(call get_isp_port)
+    endif
+else
+	AVRDUDE_ISP_OPTS += -P $(call get_isp_port)
 endif
 
 ifndef ISP_EEPROM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Add `OBJDIR` to `arduino-mk-vars.md` (https://github.com/tinyladi)
 - Tweak: *Beautify* `arduino-mk-vars.md` with code blocks. (https://github.com/tinyladi)
 - Fix: AVR tools paths for chipKIT in Linux. (https://github.com/peplin)
+- Fix: Consider usb or usb:... to be a valid ISP_PORT (https://github.com/geoffholden)
 
 ### 1.3.1 (2014-02-04)
 - Fix: BUNDLED_AVR_TOOLS_DIR is now set properly when using only arduino-core and not the whole arduino package. (https://github.com/sej7278)


### PR DESCRIPTION
AVRDUDE requires -P usb to be passed as an argument for some ISP
devices, and it is also required in the case where you have multiple
usbtiny or usbasp devices connected at once to select a specific one.

Fix #167
