### PR TITLE
Avoid hard-coded path to Python interpreter.

### DIFF
--- a/bin/ard-reset-arduino
+++ b/bin/ard-reset-arduino
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import serial
 import os.path


### PR DESCRIPTION
Using `/usr/bin/env` to find the Python interpreter makes the reset script compatible with Python virtualenvs.
