### PR TITLE
Fixed lintian "hyphen-used-as-minus-sign" warning in manpage

### DIFF
--- a/ard-reset-arduino.1
+++ b/ard-reset-arduino.1
@@ -1,7 +1,7 @@
 .TH ARD-RESET-ARDUINO "1" "April 2014" "ard-reset-arduino 1.3.3" "Arduino CLI Reset"
 
 .SH NAME
-ard-reset-arduino \- Reset Arduino board
+ard-reset-arduino - Reset Arduino board
 
 .SH SYNOPSIS
 .B ard-reset-arduino
@@ -12,21 +12,21 @@ To reset Arduinos, we either pulse the DTR line or open the USB port
 at 1200 baud and close it again.
 
 .SH OPTIONS
-.B --verbose
+.B \-\-verbose
 Watch what's going on on STDERR.
 
-.B --period
+.B \-\-period
 Specify the DTR pulse width in seconds.
 
-.B --caterina
+.B \-\-caterina
 Reset a Leonardo, Micro, Robot, LilyPadUSB or similar 32u4-based device.
 
 .SH EXAMPLES
 ard-reset-arduino /dev/ttyACM0
 .PP
-ard-reset-arduino --verbose --period=0.1 /dev/cu.usb*
+ard-reset-arduino \-\-verbose \-\-period=0.1 /dev/cu.usb*
 .PP
-ard-reset-arduino --verbose --caterina /dev/ttyUSB0
+ard-reset-arduino \-\-verbose \-\-caterina /dev/ttyUSB0
 
 .SH BUGS
 There are no known bugs in this application. Please report problems 


### PR DESCRIPTION
Stupid Debian packaging guidelines!

http://lintian.debian.org/tags/hyphen-used-as-minus-sign.html
