### PR TITLE
If no port is specified, try to guess it from wildcards

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -866,8 +866,14 @@ ifeq ($(CURRENT_OS), WINDOWS)
     COM_PORT_ID = $(subst com,,$(MONITOR_PORT))
     COM_STYLE_MONITOR_PORT = com$(COM_PORT_ID)
     DEVICE_PATH = /dev/ttyS$(shell awk 'BEGIN{ print $(COM_PORT_ID) - 1 }')
-else
+endif
+
+ifdef ARDUINO_PORT
     DEVICE_PATH = $(MONITOR_PORT)
+else
+    # If no port is specified, try to guess it from wildcards.
+    DEVICE_PATH = $(firstword $(wildcard \
+			/dev/ttyACM? /dev/ttyUSB? /dev/tty.usbserial* /dev/tty.usbmodem*))
 endif
 
 # Returns the Arduino port (first wildcard expansion) if it exists, otherwise it errors.


### PR DESCRIPTION
I believe the Makefile used to do this. I think this simplifies things for the user a little.
