### PR TITLE
Check that on windows ARDUINO_DIR (and MPIDE_DIR) is a relative path.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -279,6 +279,12 @@ else
     $(call show_config_variable,ARDUINO_DIR,[USER])
 endif
 
+ifeq ($(CURRENT_OS),WINDOWS)
+    ifneq ($(shell echo $(ARDUINO_DIR) | egrep '^(/|[a-zA-Z]:\\)'),)
+        echo $(error On Windows, ARDUINO_DIR must be a relative path)
+    endif
+endif
+
 ########################################################################
 # Default TARGET to pwd (ex Daniele Vergini)
 

--- a/chipKIT.mk
+++ b/chipKIT.mk
@@ -47,6 +47,12 @@ else
     $(call show_config_variable,MPIDE_DIR,[USER])
 endif
 
+ifeq ($(CURRENT_OS),WINDOWS)
+    ifneq ($(shell echo $(ARDUINO_DIR) | egrep '^(/|[a-zA-Z]:\\)'),)
+        echo $(error On Windows, MPIDE_DIR must be a relative path)
+    endif
+endif
+
 ifndef MPIDE_PREFERENCES_PATH
     AUTO_MPIDE_PREFERENCES_PATH := $(firstword \
         $(call dir_if_exists,$(HOME)/.mpide/preferences.txt) \


### PR DESCRIPTION
Checks for paths starting with / e.g. /cydrive/arduino or a drive letter e.g. C:\Program Files\Arduino

Fixes #201

Oh I forgot to update HISTORY.md
