### PR TITLE
"make show_boards" now lists the board name as well as board tag.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1251,7 +1251,7 @@ size:	$(TARGET_HEX)
 		$(call avr_size,$(TARGET_ELF),$(TARGET_HEX))
 
 show_boards:
-		@$(CAT) $(BOARDS_TXT) | grep -E "^[[:alnum:]]" | cut -d . -f 1 | uniq
+		@$(CAT) $(BOARDS_TXT) | grep -E "^[[:alnum:]]+.name" | sort -u | sed 's/.name=/:/' | column -s: -t
 
 monitor:
 		$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Add: Add support for compiling assembler code. (Issue #195) (https://github.com/hrobeers)
 - Add: Try to guess port from wildcards if not specified. (Issue #197) (https://github.com/tuzz)
 - Fix: Check that on windows ARDUINO_DIR (and MPIDE_DIR) is a relative path. (Issue #201 and #202) (https://github.com/sej7278)
+- Add: List board name as well as tag in `make show_boards`. (Issue #204) (https://github.com/sej7278)
 
 ### 1.3.3 (2014-04-12)
 - Fix: Make a new manpage for ard-reset-arduino. Fixes issue #188 (https://github.com/sej7278)


### PR DESCRIPTION
also is alphabetically sorted by tag now.

Fixes #204
