### PR TITLE
Add missing newlines at end of some echo's

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1257,10 +1257,10 @@ monitor:
 		$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)
 
 disasm: $(OBJDIR)/$(TARGET).lss
-		@$(ECHO) "The compiled ELF file has been disassembled to $(OBJDIR)/$(TARGET).lss"
+		@$(ECHO) "The compiled ELF file has been disassembled to $(OBJDIR)/$(TARGET).lss\n\n"
 
 symbol_sizes: $(OBJDIR)/$(TARGET).sym
-		@$(ECHO) "A symbol listing sorted by their size have been dumped to $(OBJDIR)/$(TARGET).sym"
+		@$(ECHO) "A symbol listing sorted by their size have been dumped to $(OBJDIR)/$(TARGET).sym\n\n"
 
 verify_size:
 ifeq ($(strip $(HEX_MAXIMUM_SIZE)),)
@@ -1270,37 +1270,43 @@ endif
 See http://www.arduino.cc/en/Guide/Troubleshooting#size for tips on reducing it."; false; fi
 
 generate_assembly: $(OBJDIR)/$(TARGET).s
-		@$(ECHO) "Compiler-generated assembly for the main input source has been dumped to $(OBJDIR)/$(TARGET).s"
+		@$(ECHO) "Compiler-generated assembly for the main input source has been dumped to $(OBJDIR)/$(TARGET).s\n\n"
 
 generated_assembly: generate_assembly
-		@$(ECHO) "\"generated_assembly\" target is deprecated. Use \"generate_assembly\" target instead"
+		@$(ECHO) "\"generated_assembly\" target is deprecated. Use \"generate_assembly\" target instead\n\n"
 
 help_vars:
 		@$(CAT) $(ARDMK_DIR)/arduino-mk-vars.md
 
 help:
 		@$(ECHO) "\nAvailable targets:\n\
-  make                  - no upload\n\
-  make upload           - upload\n\
-  make clean            - remove all our dependencies\n\
-  make depends          - update dependencies\n\
-  make reset            - reset the Arduino by tickling DTR on the serial port\n\
-  make raw_upload       - upload without first resetting\n\
-  make show_boards      - list all the boards defined in boards.txt\n\
-  make monitor          - connect to the Arduino's serial port\n\
-  make size             - show the size of the compiled output (relative to\n\
-                          resources, if you have a patched avr-size)\n\
-  make disasm           - generate a .lss file in build-cli that contains\n\
-                          disassembly of the compiled file interspersed\n\
-                          with your original source code.\n\
-  make verify_size      - Verify that the size of the final file is less than\n\
-                          the capacity of the micro controller.\n\
-  make eeprom           - upload the eep file\n\
-  make raw_eeprom       - upload the eep file without first resetting\n\
-  make burn_bootloader  - burn bootloader and fuses\n\
-  make set_fuses        - set fuses without burning bootloader\n\
-  make help_vars        - print all variables that can be overridden\n\
-  make help             - show this help\n\
+  make                   - compile the code\n\
+  make upload            - upload\n\
+  make ispload           - upload using an ISP\n\
+  make raw_upload        - upload without first resetting\n\
+  make eeprom            - upload the eep file\n\
+  make raw_eeprom        - upload the eep file without first resetting\n\
+  make clean             - remove all our dependencies\n\
+  make depends           - update dependencies\n\
+  make reset             - reset the Arduino by tickling DTR or changing baud\n\
+                           rate on the serial port.\n\
+  make show_boards       - list all the boards defined in boards.txt\n\
+  make monitor           - connect to the Arduino's serial port\n\
+  make size              - show the size of the compiled output (relative to\n\
+                           resources, if you have a patched avr-size).\n\
+  make verify_size       - verify that the size of the final file is less than\n\
+                           the capacity of the micro controller.\n\
+  make symbol_sizes      - generate a .sym file containing symbols and their\n\
+                           sizes.\n\
+  make disasm            - generate a .lss file that contains disassembly\n\
+                           of the compiled file interspersed with your\n\
+                           original source code.\n\
+  make generate_assembly - generate a .s file containing the compiler\n\
+                           generated assembly of the main sketch.\n\
+  make burn_bootloader   - burn bootloader and fuses\n\
+  make set_fuses         - set fuses without burning bootloader\n\
+  make help_vars         - print all variables that can be overridden\n\
+  make help              - show this help\n\
 "
 	@$(ECHO) "Please refer to $(ARDMK_DIR)/Arduino.mk for more details.\n"
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Add: Try to guess port from wildcards if not specified. (Issue #197) (https://github.com/tuzz)
 - Fix: Check that on windows ARDUINO_DIR (and MPIDE_DIR) is a relative path. (Issue #201 and #202) (https://github.com/sej7278)
 - Add: List board name as well as tag in `make show_boards`. (Issue #204) (https://github.com/sej7278)
+- Fix: Add missing newlines at end of some echo's (Issue #207) (https://github.com/sej7278)
+- Fix: Add missing/reorder/reword targets in `make help` (https://github.com/sej7278)
 
 ### 1.3.3 (2014-04-12)
 - Fix: Make a new manpage for ard-reset-arduino. Fixes issue #188 (https://github.com/sej7278)


### PR DESCRIPTION
See issue #207

Whilst doing that, i noticed that there were some missing targets to "make help" so added those in and re-ordered and re-worded some of the targets to make more sense e.g. all of the upload's are together, all of the assemblers are together etc.

And I remembered to update HISTORY.md ! ;-)
