### PR TITLE
Build core objects in subdirectory, fixes issue #82

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -684,7 +684,7 @@ ifeq ($(strip $(NO_CORE)),)
 
         CORE_OBJ_FILES  = $(CORE_C_SRCS:.c=.o) $(CORE_CPP_SRCS:.cpp=.o) $(CORE_AS_SRCS:.S=.o)
         CORE_OBJS       = $(patsubst $(ARDUINO_CORE_PATH)/%,  \
-                $(OBJDIR)/%,$(CORE_OBJ_FILES))
+                $(OBJDIR)/core/%,$(CORE_OBJ_FILES))
     endif
 else
     $(call show_config_info,NO_CORE set so core library will not be built,[MANUAL])
@@ -1016,15 +1016,15 @@ $(OBJDIR)/%.s: %.ino $(COMMON_DEPS) | $(OBJDIR)
 #	$(AS) -$(MCU_FLAG_NAME)=$(MCU) -alhnd $< > $@
 
 # core files
-$(OBJDIR)/%.o: $(ARDUINO_CORE_PATH)/%.c $(COMMON_DEPS) | $(OBJDIR)
+$(OBJDIR)/core/%.o: $(ARDUINO_CORE_PATH)/%.c $(COMMON_DEPS) | $(OBJDIR)
 	@$(MKDIR) $(dir $@)
 	$(CC) -MMD -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
-$(OBJDIR)/%.o: $(ARDUINO_CORE_PATH)/%.cpp $(COMMON_DEPS) | $(OBJDIR)
+$(OBJDIR)/core/%.o: $(ARDUINO_CORE_PATH)/%.cpp $(COMMON_DEPS) | $(OBJDIR)
 	@$(MKDIR) $(dir $@)
 	$(CXX) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
-$(OBJDIR)/%.o: $(ARDUINO_CORE_PATH)/%.S $(COMMON_DEPS) | $(OBJDIR)
+$(OBJDIR)/core/%.o: $(ARDUINO_CORE_PATH)/%.S $(COMMON_DEPS) | $(OBJDIR)
 	@$(MKDIR) $(dir $@)
 	$(CC) -MMD -c $(CPPFLAGS) $(ASFLAGS) $< -o $@
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Arduino.mk is now compatible with Flymake mode (https://github.com/rbarzic)
 - Fix: MONITOR_PORT detection (Issue #213, #215) (https://github.com/sej7278)
 - Tweak: Audited regexes/quoting/wildcards (Issue #192) (https://github.com/sej7278)
+- New: Build core objects in subdirectory (Issue #82) (https://github.com/sej7278)
 
 ### 1.3.3 (2014-04-12)
 - Fix: Make a new manpage for ard-reset-arduino. Fixes issue #188 (https://github.com/sej7278)


### PR DESCRIPTION
Fixes issue #82 

Tidies up the build-\* directory with a 4-line fix. Tested with alternate cores and multiple libraries (and even my 1.5 branch):

```
core/
libcore.a
libs/
weather24ard_txnet.d
weather24ard_txnet.eep
weather24ard_txnet.elf
weather24ard_txnet.hex
weather24ard_txnet.hex.sizeok
weather24ard_txnet.o
```
