### PR TITLE
Check if OBJDIR is defined before cleaning

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1327,7 +1327,7 @@ ifneq ($(strip $(AVRDUDE_ISP_FUSES_POST)),)
 endif
 
 clean:
-		$(REMOVE) ./$(OBJDIR)
+		$(REMOVE) $(OBJDIR)
 
 size:	$(TARGET_HEX)
 		$(call avr_size,$(TARGET_ELF),$(TARGET_HEX))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ A Makefile for Arduino Sketches
 The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
+### In development
+- Tweak: Allow remove of any OBJDIR with `$(REMOVE) $(OBJDIR)`. (https://github.com/ladislas)
+
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)
 - Add: Add support for compiling assembler code. (Issue #195) (https://github.com/hrobeers)
@@ -25,9 +28,9 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Add avr-libc/malloc.c and realloc.c to included core files. Fixes issue #163 (https://github.com/sej7278)
 - Fix: Add "gpio" to the list of isp that don't have a port. (Issue #165, #166) (https://github.com/sej7278)
 - Fix: Add "-D__PROG_TYPES_COMPAT__" to the avr-g++ compiler flags to match IDE. (https://github.com/sej7278)
-- New: Create `Makefile-example-mk`, a *real life* `Makefile` example, to be used as a reference. (https://github.com/tinyladi)
-- Tweak: Add `OBJDIR` to `arduino-mk-vars.md` (https://github.com/tinyladi)
-- Tweak: *Beautify* `arduino-mk-vars.md` with code blocks. (https://github.com/tinyladi)
+- New: Create `Makefile-example-mk`, a *real life* `Makefile` example, to be used as a reference. (https://github.com/ladislas)
+- Tweak: Add `OBJDIR` to `arduino-mk-vars.md` (https://github.com/ladislas)
+- Tweak: *Beautify* `arduino-mk-vars.md` with code blocks. (https://github.com/ladislas)
 - Fix: AVR tools paths for chipKIT in Linux. (https://github.com/peplin)
 - Fix: Consider usb or usb:... to be a valid ISP_PORT (https://github.com/geoffholden)
 - Add: Add phony target to run pre-build hook script (https://github.com/jrid)
@@ -64,7 +67,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Show correct path to `arduino.mk` file in help message. Fix #120
 - Change echo for printf. Fix #129 (https://github.com/thomassigurdsen)
 - Add support for ChipKiT 2013. Fix #136 (https://github.com/peplin)
-- Auto detect and include libraries specified in `USER_LIB_PATH`. Fix #135 (https://github.com/tinyladi)
+- Auto detect and include libraries specified in `USER_LIB_PATH`. Fix #135 (https://github.com/ladislas)
 - Use `MAKEFILE_LIST` to get the name of the make file. Fix #130 (https://github.com/cantora)
 - New: Add option to set fuses without burning a bootloader. Fix #141 (https://github.com/sej7278)
 - Tweak: Don't append port details to avrdude for usbtiny. Fix #140 and #138 (https://github.com/PPvG)


### PR DESCRIPTION
`make clean` remove `OBJDIR` only if it is in the same directory.

If the user has set `OBJDIR` to a different directory, it would not clean anything.

Just added a check on wether `OBJDIR` is defined or not. 
