### PR TITLE
Using CFLAGS_STD and CPPFLAGS_STD

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -931,8 +931,15 @@ else
     $(call show_config_variable,CFLAGS_STD,[USER])
 endif
 
-CFLAGS        += $(EXTRA_FLAGS) $(EXTRA_CFLAGS)
-CXXFLAGS      += -fno-exceptions $(EXTRA_FLAGS) $(EXTRA_CXXFLAGS)
+ifndef CPPFLAGS_STD
+    CPPFLAGS_STD        = -std=c++0x
+    $(call show_config_variable,CPPFLAGS_STD,[DEFAULT])
+else
+    $(call show_config_variable,CPPFLAGS_STD,[USER])
+endif
+
+CFLAGS        += $(CFLAGS_STD) $(EXTRA_FLAGS) $(EXTRA_CFLAGS)
+CXXFLAGS      += -fno-exceptions $(CPPFLAGS_STD) $(EXTRA_FLAGS) $(EXTRA_CXXFLAGS)
 ASFLAGS       += -x assembler-with-cpp
 LDFLAGS       += -$(MCU_FLAG_NAME)=$(MCU) -Wl,--gc-sections -O$(OPTIMIZATION_LEVEL) $(EXTRA_FLAGS) $(EXTRA_CXXFLAGS) $(EXTRA_LDFLAGS)
 SIZEFLAGS     ?= --mcu=$(MCU) -C

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Make avr-g++ use CXXFLAGS instead of CFLAGS. (https://github.com/sej7278)
 - Add: Add information about overriding system libs (Issue #229). (https://github.com/sej7278)
 - Add: Add information about reporting bugs to the correct project (Issue #231). (https://github.com/sej7278)
+- Fix: Create CPPFLAGS_STD variable and add CFLAGS_STD and CPPFLAGS_STD to CFLAGS and CXXFLAGS (http://github.com/ladislas)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -798,6 +798,24 @@ Defaults to `-std=gnu99`
 
 ----
 
+### CPPFLAGS_STD
+
+**Description:**
+
+Flags to pass to the C compiler.
+
+Defaults to `-std=c++0x`
+
+**Example:**
+
+```Makefile
+CPPFLAGS_STD = -std=gnu++14
+```
+
+**Requirement:** *Optional*
+
+----
+
 ### OVERRIDE_EXECUTABLES
 
 **Description:**


### PR DESCRIPTION
Hi there!

I tweaked `Arduino.mk` to use `CFLAGS_STD` the flags and added `CPPFLAGS_STD` for `c++`.

They can now be set in your `Makefile`.

Also changed `HISTORY.md` and `arduino-mk-vars.md`.

Hope it helps! :)
