### PR TITLE
CFLAGS_STD and CXXFLAGS_STD

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -925,16 +925,23 @@ ifneq ($(CATERINA),)
 endif
 
 ifndef CFLAGS_STD
-    CFLAGS_STD        = -std=gnu99
+    CFLAGS_STD        =
     $(call show_config_variable,CFLAGS_STD,[DEFAULT])
 else
     $(call show_config_variable,CFLAGS_STD,[USER])
 endif
 
-CFLAGS        += $(EXTRA_FLAGS) $(EXTRA_CFLAGS)
-CXXFLAGS      += -fno-exceptions $(EXTRA_FLAGS) $(EXTRA_CXXFLAGS)
+ifndef CXXFLAGS_STD
+    CXXFLAGS_STD      =
+    $(call show_config_variable,CXXFLAGS_STD,[DEFAULT])
+else
+    $(call show_config_variable,CXXFLAGS_STD,[USER])
+endif
+
+CFLAGS        += $(CFLAGS_STD)
+CXXFLAGS      += -fno-exceptions $(CXXFLAGS_STD)
 ASFLAGS       += -x assembler-with-cpp
-LDFLAGS       += -$(MCU_FLAG_NAME)=$(MCU) -Wl,--gc-sections -O$(OPTIMIZATION_LEVEL) $(EXTRA_FLAGS) $(EXTRA_CXXFLAGS) $(EXTRA_LDFLAGS)
+LDFLAGS       += -$(MCU_FLAG_NAME)=$(MCU) -Wl,--gc-sections -O$(OPTIMIZATION_LEVEL)
 SIZEFLAGS     ?= --mcu=$(MCU) -C
 
 # for backwards compatibility, grab ARDUINO_PORT if the user has it set

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,11 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Make avr-g++ use CXXFLAGS instead of CFLAGS. (https://github.com/sej7278)
 - Add: Add information about overriding system libs (Issue #229). (https://github.com/sej7278)
 - Add: Add information about reporting bugs to the correct project (Issue #231). (https://github.com/sej7278)
+- Fix: Allow the use of CFLAGS_STD and CXXFLAGS_STD and set defaults (Issue #234) (https://github.com/ladislas)
+- Tweak: Remove \$(EXTRA_XXX) variables (Issue #234) (https://github.com/ladislas)
+- Add: Add documentation about CFLAGS_STD and CXXFLAGS_STD (Issue #234) (https://github.com/ladislas)
+- Tweak: Update Malefile-example.mk with STD flags (https://github.com/ladislas)
+
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -784,14 +784,70 @@ OPTIMIZATION_LEVEL = 3
 
 **Description:**
 
-Flags to pass to the C compiler.
+Controls, *exclusively*, which C standard is to be used for compilation.
 
-Defaults to `-std=gnu99`
+Defaults to `undefined`
+
+Possible values:
+
+*	With `avr-gcc 4.3`, shipped with the Arduino IDE:
+	*	`undefined`
+	*	`-std=c99`
+	*	`-std=gnu89` - This is the default for C code
+	*	`-std=gnu99`
+*	With `avr-gcc 4.7, 4.8 or 4.9`, installed by you
+	*	`undefined`
+	*	`-std=c99`
+	*	`-std=c11`
+	*	`-std=gnu89` - This is the default for C code
+	*	`-std=gnu99`
+	*	`-std=gnu11`
+
+For more information, please refer to the [Options Controlling C Dialect](https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html)
 
 **Example:**
 
 ```Makefile
-<unset as per chipKIT.mk>
+CFLAGS_STD = = -std=gnu89
+```
+
+**Requirement:** *Optional*
+
+----
+
+### CXXFLAGS_STD
+
+**Description:**
+
+Controls, *exclusively*, which C++ standard is to be used for compilation.
+
+Defaults to `undefined`
+
+Possible values:
+
+*	With `avr-gcc 4.3`, shipped with the Arduino IDE:
+	*	`undefined`
+	*	`-std=c++98`
+	*	`-std=c++0x`
+	*	`-std=gnu++98` - This is the default for C code
+	*	`-std=gnu++0x`
+*	With `avr-gcc 4.7, 4.8 or 4.9`, installed by you
+	*	`undefined`
+	*	`-std=c++98`
+	*	`-std=c++11`
+	*	`-std=c++1y`
+	*	`-std=c++14`
+	*	`-std=gnu++98` - This is the default for C++ code
+	*	`-std=gnu++11`
+	*	`-std=gnu++1y`
+	*	`-std=gnu++14`
+
+For more information, please refer to the [Options Controlling C Dialect](https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html)
+
+**Example:**
+
+```Makefile
+CXXFLAGS_STD = = -std=gnu++98
 ```
 
 **Requirement:** *Optional*

--- a/examples/MakefileExample/Makefile-example.mk
+++ b/examples/MakefileExample/Makefile-example.mk
@@ -2,26 +2,30 @@
 ### This is an example Makefile and it MUST be configured to suit your needs.
 ### For detailled explanations about all the avalaible options,
 ### please refer to https://github.com/sudar/Arduino-Makefile/blob/master/arduino-mk-vars.md
+### Original project where this Makefile comes from: https://github.com/WeAreLeka/Bare-Arduino-Project
 
 ### PROJECT_DIR
 ### This is the path to where you have created/cloned your project
-PROJECT_DIR       = /Users/Ladislas/dev/leka/moti
+PROJECT_DIR       = /Users/MyUserName/path/to/my/Project
 
 ### ARDMK_DIR
 ### Path to the Arduino-Makefile directory.
-ARDMK_DIR         = $(PROJECT_DIR)/arduino-mk
+ARDMK_DIR         = $(PROJECT_DIR)/Arduino-Makefile
 
 ### ARDUINO_DIR
 ### Path to the Arduino application and ressources directory.
+### On OS X:
 ARDUINO_DIR       = /Applications/Arduino.app/Contents/Resources/Java
+### or on Linux: (remove the one you don't want)
+ARDUINO_DIR       = /usr/share/arduino
 
 ### USER_LIB_PATH
 ### Path to where the your project's libraries are stored.
-USER_LIB_PATH     :=  $(PROJECT_DIR)/lib
+USER_LIB_PATH    :=  $(PROJECT_DIR)/lib
 
 ### BOARD_TAG
 ### It must be set to the board you are currently using. (i.e uno, mega2560, etc.)
-BOARD_TAG         = mega2560
+BOARD_TAG         = uno
 
 ### MONITOR_BAUDRATE
 ### It must be set to Serial baudrate value you are using.
@@ -29,21 +33,36 @@ MONITOR_BAUDRATE  = 115200
 
 ### AVR_TOOLS_DIR
 ### Path to the AVR tools directory such as avr-gcc, avr-g++, etc.
+### On OS X with `homebrew`:
 AVR_TOOLS_DIR     = /usr/local
+### or on Linux: (remove the one you don't want)
+AVR_TOOLS_DIR     = /usr/bin
 
 ### AVRDDUDE
 ### Path to avrdude directory.
+### On OS X with `homebrew`:
 AVRDDUDE          = /usr/local/bin/avrdude
+### or on Linux: (remove the one you don't want)
+AVRDDUDE          = /usr/bin/avrdude
 
-### CPPFLAGS
+### CFLAGS_STD
+### Set the C standard to be used during compilation. Documentation (https://github.com/WeAreLeka/Arduino-Makefile/blob/std-flags/arduino-mk-vars.md#cflags_std)
+CFLAGS_STD        = -std=gnu11
+
+### CXXFLAGS_STD
+### Set the C++ standard to be used during compilation. Documentation (https://github.com/WeAreLeka/Arduino-Makefile/blob/std-flags/arduino-mk-vars.md#cxxflags_std)
+CXXFLAGS_STD      = -std=gnu++11
+
+### CXXFLAGS
 ### Flags you might want to set for debugging purpose. Comment to stop.
-CPPFLAGS         = -pedantic -Wall -Wextra
+CXXFLAGS         += -pedantic -Wall -Wextra
 
 ### MONITOR_PORT
 ### The port your board is connected to. Using an '*' tries all the ports and finds the right one.
 MONITOR_PORT      = /dev/tty.usbmodem*
 
-### don't touch this
+### CURRENT_DIR
+### Do not touch - used for binaries path
 CURRENT_DIR       = $(shell basename $(CURDIR))
 
 ### OBJDIR


### PR DESCRIPTION
This is the new pull request regarding the `XFLAGS_STD` and is a follow up of the https://github.com/sudar/Arduino-Makefile/pull/233 pull request.

**Nothing is set yet, modifications are welcome and I'll clean everything once everything is decided**

The description below should answers @sej7278's questions from https://github.com/sudar/Arduino-Makefile/pull/233#issuecomment-51969811. **All the tests are made with the binaries shipped with the Arduino IDE.**
## STD flags

The default `CFLAGS_STD` is `-std=gnu99` and **has not changed**.

Regarding the default `CPPFLAGS_STD`, there seems to be different options :
- `undefined` - left blank - code **_does**_ compile :+1: 
- `-std=gnu++98` - [1998 standard](https://gcc.gnu.org/onlinedocs/gcc/Standards.html) - code **_does**_ compile :+1: 
- `-std=gnu++03` - [2003 amendment](https://gcc.gnu.org/onlinedocs/gcc/Standards.html) - code **does not** compile, option not recognized :-1: 
- `-std=gnu++11` - [2011 standard](https://gcc.gnu.org/projects/cxx0x.html) - code **does not** compiles, option not recognized because `avr-gcc 4.7` or higher is needed :-1: 
- `-std=gnu++0x` - [2011 standard](https://gcc.gnu.org/projects/cxx0x.html) - code **_does**_ compile, because the option is compatible with `avr-gcc 4.3.2` shipped with the Arduino IDE :+1:

**_Conclusion:**_ `undefined` works and only relies on the Arduino binaries, so it might be the safest choice. On the other hand `gnu++0x` works as well and gives more freedom regarding comments and code. And as the next version of the IDE will ship with `avr-gcc 4.8`, it might be progressive choice. **The discussion is open**.
## EXTRA flags

They have been removed be I can add them back if needed. I don't think they are useful, there is no documentation about them and the names are misleading I think.
## Documentation

I'll add everything once we are set up.
## Conclusion

Feedbacks are more than welcome! :)
