### PR TITLE
MakefileExample: Fix AVR_TOOLS_DIR default

### DIFF
--- a/examples/MakefileExample/Makefile-example.mk
+++ b/examples/MakefileExample/Makefile-example.mk
@@ -36,7 +36,7 @@ MONITOR_BAUDRATE  = 115200
 ### On OS X with `homebrew`:
 AVR_TOOLS_DIR     = /usr/local
 ### or on Linux: (remove the one you don't want)
-AVR_TOOLS_DIR     = /usr/bin
+AVR_TOOLS_DIR     = /usr
 
 ### AVRDDUDE
 ### Path to avrdude directory.


### PR DESCRIPTION
Judging by the default for OS X directly above it and the fact that the current default doesn't work, it seems this should not include the `/bin`.
