### PR TITLE
Fix regex for "make show_boards" on 1.5

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1340,7 +1340,7 @@ size:	$(TARGET_HEX)
 		$(call avr_size,$(TARGET_ELF),$(TARGET_HEX))
 
 show_boards:
-		@$(CAT) "$(BOARDS_TXT)" | grep -E "^[[:alnum:]]+.name" | sort -uf | sed 's/.name=/:/' | column -s: -t
+		@$(CAT) "$(BOARDS_TXT)" | grep -E "^[a-zA-Z0-9_]+.name" | sort -uf | sed 's/.name=/:/' | column -s: -t
 
 monitor:
 		$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Add: Add documentation about CFLAGS_STD and CXXFLAGS_STD (Issue #234) (https://github.com/ladislas)
 - Tweak: Update Malefile-example.mk with STD flags (https://github.com/ladislas)
 - Add: Allow "make clean" target to be extended (Issue #239). (https://github.com/sej7278)
+- Fix: Update "make show_boards" regex to work with the Due in 1.5. (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)


### PR DESCRIPTION
In 1.5.6 the Due board has an underscore, this regex tweak allows for:

arduino_due_x_dbg  Arduino Due (Programming Port)
arduino_due_x      Arduino Due (Native USB Port)
