### PR TITLE
Replaced double quotes with singles when....

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1132,7 +1132,7 @@ endif
 
 $(OBJDIR)/%.eep: $(OBJDIR)/%.elf $(COMMON_DEPS)
 	@$(MKDIR) $(dir $@)
-	-$(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" \
+	-$(OBJCOPY) -j .eeprom --set-section-flags=.eeprom='alloc,load' \
 		--change-section-lma .eeprom=0 -O ihex $< $@
 
 $(OBJDIR)/%.lss: $(OBJDIR)/%.elf $(COMMON_DEPS)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Update "make show_boards" regex to work with the Due in 1.5. (https://github.com/sej7278)
 - Fix: Allow user libaries/sketches to have the same name as system libs. (Issue #244, #229). (https://github.com/sej7278)
 - Fix: Remove impact of travis-ci from regular users. (Issue #258). (https://github.com/sej7278)
+- Fix: objcopy quoting issue on Windows. (Issue #272). (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)


### PR DESCRIPTION
......passing arguments to avr-objcopy. Windows doesn't seem to like double quotes.

Fixes issue #272, thanks @vogt31337

Does seem to break Linux, and its a simple fix so :+1: 
