### PR TITLE
Add's "avrispmkii" to the list of ISP's that don't have a port

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1310,7 +1310,7 @@ endif
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
 ifndef $(ISP_PORT)
-    ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio))
+    ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio avrispmkii))
         AVRDUDE_ISP_OPTS += -P $(call get_isp_port)
     endif
 else

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Allow user libaries/sketches to have the same name as system libs. (Issue #244, #229). (https://github.com/sej7278)
 - Fix: Remove impact of travis-ci from regular users. (Issue #258). (https://github.com/sej7278)
 - Fix: objcopy quoting issue on Windows. (Issue #272). (https://github.com/sej7278)
+- Fix: Add "avrispmkii" to the list of isp that don't have a port. (Issue #279). (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)


### PR DESCRIPTION
defaults to reading communication_type from avrdude.conf rather than explicitly setting the -P flag which is the user override.

fixes (mostly) issue #279
