### PR TITLE
Made CXX compile *.cpp files instead of CC.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1079,7 +1079,7 @@ $(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.c
 
 $(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.cpp
 	@$(MKDIR) $(dir $@)
-	$(CC) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+	$(CXX) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 $(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.S
 	@$(MKDIR) $(dir $@)
@@ -1091,7 +1091,7 @@ $(OBJDIR)/platformlibs/%.o: $(ARDUINO_PLATFORM_LIB_PATH)/%.c
 
 $(OBJDIR)/platformlibs/%.o: $(ARDUINO_PLATFORM_LIB_PATH)/%.cpp
 	@$(MKDIR) $(dir $@)
-	$(CC) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+	$(CXX) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 $(OBJDIR)/platformlibs/%.o: $(ARDUINO_PLATFORM_LIB_PATH)/%.S
 	@$(MKDIR) $(dir $@)
@@ -1099,7 +1099,7 @@ $(OBJDIR)/platformlibs/%.o: $(ARDUINO_PLATFORM_LIB_PATH)/%.S
 
 $(OBJDIR)/userlibs/%.o: $(USER_LIB_PATH)/%.cpp
 	@$(MKDIR) $(dir $@)
-	$(CC) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+	$(CXX) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 $(OBJDIR)/userlibs/%.o: $(USER_LIB_PATH)/%.c
 	@$(MKDIR) $(dir $@)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Remove impact of travis-ci from regular users. (Issue #258). (https://github.com/sej7278)
 - Fix: objcopy quoting issue on Windows. (Issue #272). (https://github.com/sej7278)
 - Fix: Add "avrispmkii" to the list of isp that don't have a port. (Issue #279). (https://github.com/sej7278)
+- Fix: Make CXX compile .cpp files instead of CC. (Issue #285). (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)


### PR DESCRIPTION
Fixes issue #285 where $(CC) was compiling *.cpp files instead of $(CXX)

Introduced in commit 7b74e10, copy'n'paste error.

Doesn't actually break anything as gcc can compile C++ programs, only the linker may have difficulty.
