### PR TITLE
Allow avrdude to erase the chip before programming during ispload

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1209,10 +1209,8 @@ endif
 # Default avrdude options
 # -V Do not verify
 # -q - suppress progress output
-# -D - Disable auto erase for flash memory
-# (-D is needed for Mega boards. See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
 ifndef AVRDUDE_OPTS
-    AVRDUDE_OPTS = -q -V -D
+    AVRDUDE_OPTS = -q -V
 endif
 
 AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) -p $(MCU)
@@ -1220,7 +1218,9 @@ ifdef AVRDUDE_CONF
     AVRDUDE_COM_OPTS += -C $(AVRDUDE_CONF)
 endif
 
-AVRDUDE_ARD_OPTS = -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
+# -D - Disable auto erase for flash memory
+# (-D is needed for Mega boards. See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
+AVRDUDE_ARD_OPTS = -D -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
 ifeq ($(CURRENT_OS), WINDOWS)
     # get_monitor_port checks to see if the monitor port exists, assuming it is
     # a file. In Windows, avrdude needs the port in the format 'com1' which is

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Add "avrispmkii" to the list of isp that don't have a port. (Issue #279). (https://github.com/sej7278)
 - Fix: Make CXX compile .cpp files instead of CC. (Issue #285). (https://github.com/sej7278)
 - Fix: Changed IDE download URL *again* for Travis-CI. (https://github.com/sej7278)
+- Fix: Allow avrdude to erase the chip before programming during ispload (https://github.com/tchebb)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -1195,7 +1195,7 @@ AVRDUDE_ISP_BAUDRATE = 19200
 
 Options to pass to `avrdude`.
 
-Defaults to `-q -V -D` (quiet, don't verify, don't auto-erase). User values are not *ANDed* to the defaults, you have to set each option you require.
+Defaults to `-q -V` (quiet, don't verify). User values are not *ANDed* to the defaults, you have to set each option you require.
 
 **Example:**
 


### PR DESCRIPTION
We currently pass the `-D` (do not erase) option to `avrdude` unconditionally in order to work around an Arduino Mega bootloader bug. However, this has the side-effect of breaking the `ispload` target for all non-XMEGA chips, since a write operation on these chips essentially ANDs the new program with the existing memory contents. If the memory is not first erased to contain only `0xff`, the resulting image is garbage. This patch makes it so we pass `-D` when we're using the Arduino bootloader but don't pass it when we're using ISP directly.

Note: I wasn't able to test this patch with an Arduino Mega, since I don't have one. However, it ought to generate an identical `avrdude` command line as it did before (except for switching the order of a couple arguments), so I'm as sure as I can be that it won't cause any new bugs.
