### PR TITLE
Arduino changed the download link again

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: objcopy quoting issue on Windows. (Issue #272). (https://github.com/sej7278)
 - Fix: Add "avrispmkii" to the list of isp that don't have a port. (Issue #279). (https://github.com/sej7278)
 - Fix: Make CXX compile .cpp files instead of CC. (Issue #285). (https://github.com/sej7278)
+- Fix: Changed IDE download URL *again* for Travis-CI. (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)

--- a/tests/script/bootstrap/arduino.sh
+++ b/tests/script/bootstrap/arduino.sh
@@ -20,7 +20,7 @@ if [ -z "$ARDUINO_DIR" ] || ! test -e $ARDUINO_DIR || [ $OS == "cygwin" ]; then
         EXTRACT_COMMAND="tar -xzf"
     fi
 
-    ARDUINO_URL=http://downloads.arduino.cc/$ARDUINO_FILE
+    ARDUINO_URL=http://arduino.cc/download.php?f=/$ARDUINO_FILE
 
     _pushd $DEPENDENCIES_FOLDER
     if ! test -e $ARDUINO_FILE


### PR DESCRIPTION
This time it uses a script, curl handles it ok luckily.

The "old" link was: http://downloads.arduino.cc/arduino-1.0.6-linux64.tgz

But now that returns a 404, and you have to go via the script:

http://arduino.cc/download.php?f=/arduino-1.0.6-linux64.tgz

Which then generates a unique URL and uses a 302 redirect to something like:

http://downloads.arduino.cc/arduino-1.0.6-linux64.tgz?AWSAccessKeyId=hKqOiStmqc_Y3-9k2xue&Expires=1415414377&Signature=Z64EWZiAnm7dMBY4gj2XGE2WKtk%3D

Annoyingly all PR's will fail the tests until this one is merged.
