### PR TITLE
Added support for PuTTY on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ On Windows (using cygwin), you might want to set:
     MONITOR_PORT  = com3
     BOARD_TAG     = mega2560
 
+On Windows (using MSYS and PuTTY), you might want to set the following extra parameters:
+
+    MONITOR_CMD   = putty
+    MONITOR_PARMS = 8,1,n,N
+
 On Arduino 1.5.x installs, you should set the architecture to either `avr` or `sam` and if using a submenu CPU, then also set that:
 
 	ARCHITECTURE  = avr


### PR DESCRIPTION
For PuTTY, use
MONITOR_CMD=putty

The optional parameter MONITOR_PARMS can be used as well, which will be passed to PuTTY, eg.
MONITOR_PARMS=8,1,n,N

Please note that this changes the default behaviour of get_monitor_port under Windows (which technically isn't needed for PuTTY support).
Tested on Windows under MSYS, NOT on Windows under Cygwin or *nix
