### PR TITLE
Added support for PuTTY on Windows

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1419,7 +1419,15 @@ show_boards:
 		@$(CAT) "$(BOARDS_TXT)" | grep -E "^[a-zA-Z0-9_]+.name" | sort -uf | sed 's/.name=/:/' | column -s: -t
 
 monitor:
-		$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)
+ifneq ("$(MONITOR_CMD)", "putty")
+	$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)
+else
+    ifneq ($(strip $(MONITOR_PARMS)),)
+		$(MONITOR_CMD) -serial -sercfg $(MONITOR_BAUDRATE),$(MONITOR_PARMS) $(call get_monitor_port)
+    else
+		$(MONITOR_CMD) -serial -sercfg $(MONITOR_BAUDRATE) $(call get_monitor_port)
+    endif
+endif
 
 disasm: $(OBJDIR)/$(TARGET).lss
 		@$(ECHO) "The compiled ELF file has been disassembled to $(OBJDIR)/$(TARGET).lss\n\n"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In development
+- New: Support for PuTTY under Windows (https://github.com/PeterMosmans)
 - New: Add support for new 1.5.x library layout (Issue #275) (https://github.com/lukasz-e)
 - New: Add support for 1.5.x vendor/hardware architecture library location (Issue #276) (https://github.com/lukasz-e)
 - New: Added test suite and integration with travis CI. (https://github.com/peplin)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ On Windows (using cygwin), you might want to set:
     MONITOR_PORT  = com3
     BOARD_TAG     = mega2560
 
+On Windows (using MSYS and PuTTY), you might want to set the following extra parameters:
+
+    MONITOR_CMD   = putty
+    MONITOR_PARMS = 8,1,n,N
+
 On Arduino 1.5.x installs, you should set the architecture to either `avr` or `sam` and if using a submenu CPU, then also set that:
 
 	ARCHITECTURE  = avr


### PR DESCRIPTION
(rewrite of #295 after #297)

For PuTTY, use
MONITOR_CMD=putty

The optional parameter MONITOR_PARMS can be used as well, which will be passed to PuTTY, eg.
MONITOR_PARMS=8,1,n,N

Tested on Windows with Cygwin and MSYS
