### PR TITLE
Removed all double-quoting except for comments/echo's

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -276,7 +276,7 @@ ifndef ARDUINO_VERSION
     # Remove all the decimals, and right-pad with zeros, and finally grab the first 3 bytes.
     # Works for 1.0 and 1.0.1
     VERSION_FILE := $(ARDUINO_DIR)/lib/version.txt
-    AUTO_ARDUINO_VERSION := $(shell [ -e "$(VERSION_FILE)" ] && cat "$(VERSION_FILE)" | sed -e 's/^[0-9]://g' -e 's/[.]//g' -e 's/$$/0000/' | head -c3)
+    AUTO_ARDUINO_VERSION := $(shell [ -e $(VERSION_FILE) ] && cat $(VERSION_FILE) | sed -e 's/^[0-9]://g' -e 's/[.]//g' -e 's/$$/0000/' | head -c3)
     ifdef AUTO_ARDUINO_VERSION
         ARDUINO_VERSION = $(AUTO_ARDUINO_VERSION)
         $(call show_config_variable,ARDUINO_VERSION,[AUTODETECTED])
@@ -343,8 +343,8 @@ ifndef ARDUINO_SKETCHBOOK
     endif
 
     ifneq ($(ARDUINO_PREFERENCES_PATH),)
-        ARDUINO_SKETCHBOOK := $(shell grep --max-count=1 --regexp="sketchbook.path=" \
-                                          "$(ARDUINO_PREFERENCES_PATH)" | \
+        ARDUINO_SKETCHBOOK := $(shell grep --max-count=1 --regexp='sketchbook.path=' \
+                                          $(ARDUINO_PREFERENCES_PATH) | \
                                      sed -e 's/sketchbook.path=//' )
     endif
 
@@ -549,7 +549,7 @@ endif
 
 ifndef PARSE_BOARD
     # result = $(call READ_BOARD_TXT, 'boardname', 'parameter')
-    PARSE_BOARD = $(shell grep -v "^\#" "$(BOARDS_TXT)" | grep $(1).$(2) | cut -d = -f 2 )
+    PARSE_BOARD = $(shell grep -v '^\#' $(BOARDS_TXT) | grep $(1).$(2) | cut -d = -f 2 )
 endif
 
 # If NO_CORE is set, then we don't have to parse boards.txt file
@@ -777,11 +777,11 @@ endif
 ifndef ARDUINO_LIBS
     # automatically determine included libraries
     ARDUINO_LIBS += $(filter $(notdir $(wildcard $(ARDUINO_DIR)/libraries/*)), \
-        $(shell sed -ne "s/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p" $(LOCAL_SRCS)))
+        $(shell sed -ne 's/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p' $(LOCAL_SRCS)))
     ARDUINO_LIBS += $(filter $(notdir $(wildcard $(ARDUINO_SKETCHBOOK)/libraries/*)), \
-        $(shell sed -ne "s/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p" $(LOCAL_SRCS)))
+        $(shell sed -ne 's/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p' $(LOCAL_SRCS)))
     ARDUINO_LIBS += $(filter $(notdir $(wildcard $(USER_LIB_PATH)/*)), \
-        $(shell sed -ne "s/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p" $(LOCAL_SRCS)))
+        $(shell sed -ne 's/^ *\# *include *[<\"]\(.*\)\.h[>\"]/\1/p' $(LOCAL_SRCS)))
 endif
 
 ########################################################################
@@ -1416,10 +1416,10 @@ size:	$(TARGET_HEX)
 		$(call avr_size,$(TARGET_ELF),$(TARGET_HEX))
 
 show_boards:
-		@$(CAT) "$(BOARDS_TXT)" | grep -E "^[a-zA-Z0-9_]+.name" | sort -uf | sed 's/.name=/:/' | column -s: -t
+		@$(CAT) $(BOARDS_TXT) | grep -E '^[a-zA-Z0-9_]+.name' | sort -uf | sed 's/.name=/:/' | column -s: -t
 
 monitor:
-ifneq ("$(MONITOR_CMD)", "putty")
+ifneq ($(MONITOR_CMD), 'putty')
 	$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)
 else
     ifneq ($(strip $(MONITOR_PARMS)),)
@@ -1449,7 +1449,7 @@ generated_assembly: generate_assembly
 		@$(ECHO) "\"generated_assembly\" target is deprecated. Use \"generate_assembly\" target instead\n\n"
 
 help_vars:
-		@$(CAT) "$(ARDMK_DIR)/arduino-mk-vars.md"
+		@$(CAT) $(ARDMK_DIR)/arduino-mk-vars.md
 
 help:
 		@$(ECHO) "\nAvailable targets:\n\

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Changed IDE download URL *again* for Travis-CI. (https://github.com/sej7278)
 - Fix: Allow avrdude to erase the chip before programming during ispload (https://github.com/tchebb)
 - Fix: Fix speed regression. Thanks ladislas (Issue #280) (https://github.com/sej7278)
+- Fix: Removed some double quotes that were breaking variable expansion. (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)


### PR DESCRIPTION
Double-quoting was added in 7618da7 to allow for spaces in paths, that was a bad idea as:
1. most GNU Make functions can't handle spaces
2. it breaks variable expansion on Linux/OSX e.g. ~/sketchbook
3. Windows doesn't like double-quotes - see d5c7ed1

So basically, don't put spaces in your paths, as most Make functions can't handle them, even if escaped, and its a bit dangerous when shelling out to grep etc. Single-quoting is no better either.

Tested on Debian w/1.0.6/1.0.5 and Mavericks w/1.0.5 - variable expansion works again, spaces don't.

Ooh issue 300 !
