### PR TITLE
Moved location of avrdude and avrdude.conf for 1.5.8 on Linux (only!)

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -403,11 +403,20 @@ ifndef AVR_TOOLS_DIR
         ifeq ($(CURRENT_OS),LINUX)
 
             ifndef AVRDUDE
-                AVRDUDE = $(AVR_TOOLS_DIR)/../avrdude
+                ifeq ($(shell expr $(ARDUINO_VERSION) '>' 157), 1)
+                    # 1.5.8 has different location than all prior versions!
+                    AVRDUDE = $(AVR_TOOLS_DIR)/bin/avrdude
+                else
+                    AVRDUDE = $(AVR_TOOLS_DIR)/../avrdude
+                endif
             endif
 
             ifndef AVRDUDE_CONF
-                AVRDUDE_CONF = $(AVR_TOOLS_DIR)/../avrdude.conf
+                ifeq ($(shell expr $(ARDUINO_VERSION) '>' 157), 1)
+                    AVRDUDE_CONF = $(AVR_TOOLS_DIR)/etc/avrdude.conf
+                else
+                    AVRDUDE_CONF = $(AVR_TOOLS_DIR)/../avrdude.conf
+                endif
             endif
 
         else

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Update travis-ci to test against Arduino 1.0.6. (https://github.com/sej7278)
 - Tweak: Updated package instructions for Arch/Fedora/Raspbian. (https://github.com/sej7278)
 - Tweak: Remove $(EXTRA_XXX) variables (Issue #234) (https://github.com/ladislas)
+- Tweak: Moved location of avrdude for 1.5.8 on Linux (Issue #301) (https://github.com/sej7278)
 
 - Fix: Improved Windows (Cygwin/MSYS) support (https://github.com/PeterMosmans)
 - Fix: Change "tinyladi" username to "ladislas" in HISTORY.md. (https://github.com/ladislas)


### PR DESCRIPTION
Subject to change during the beta phase, as its already different to 1.5.6r2, also may change when packaged for Debian which tend to symlink the system avr\* files as a workaround.

Fixes issue #301
