### PR TITLE
Do not add '.' to gcc includes search path

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -967,7 +967,7 @@ endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
 CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) $(ARDUINO_ARCH_FLAG) -D__PROG_TYPES_COMPAT__ \
-        -I. -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
+        -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections
 


### PR DESCRIPTION
Include files are searched for in the include search path made up
from, among other places, the -I switches given to the gcc compiler.
The . (dot) used for the current directory is not in the search
path when the IDE builds the project and does not seem to be needed
in any reasonable case.  Maybe it was included because someone thought
it meant to "search in the same directory as the file being compiled",
but I cannot tell because the switch was already included in the first
commit in this repo.  In any case, the current file directory is already
searched by gcc before the search path is consulted, in any case, so
this switch is not needed to cause this behavior.

Including the "-I."  switch causes compiles to fail when libraries
include a header which is coincidentally named the same as one of the
user headers.  For example, if the user has a Udp.h file in his sketch
folder, the compile will fail if it includes the EthernetUdp.h file.

A simple example is the examples/WebServer code. It fails if you do
this:

   touch examples/WebServer/Udp.h
   make -C examples/WebServer

But it builds ok from the IDE which does not include "." in the
search path.

Similarly, HelloWorld fails for the same reason if you do this:

   touch examples/HelloWorld/Print.h
   make -C examples/HelloWorld

Remove the -I. switch from the CPPFLAGS directive altogether to
prevent this include filename confusion and to more closely model
the behavior of the IDE.  Fixes #303.

It may also work to move the -I. to the end of the search path,
but this still would compile differently from the IDE and so it
is considered not to be a useful feature to retain in any case.
## 

I did not add a test case here because it's not clear to me how it
should be added.  Should I modify HelloWorld as described above,
or should I add examples/TestSearchPath/ with the same files
explicitly for this test?  It would be clearer for me if there
was an explicit "tests" directory independent from "examples".
