### PR TITLE
enabled compilation for other usb devices

### DIFF
--- a/Teensy.mk
+++ b/Teensy.mk
@@ -135,8 +135,12 @@ endif
 
 ########################################################################
 # FLAGS
+ifndef USB_TYPE
+    USB_TYPE = USB_SERIAL
+endif
 
-CPPFLAGS += -DLAYOUT_US_ENGLISH -DUSB_SERIAL
+CPPFLAGS += -DLAYOUT_US_ENGLISH -D$(USB_TYPE)
+
 CPPFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.option)
 
 CXXFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.cppoption)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -452,6 +452,32 @@ VARIANT = leonardo
 
 ----
 
+### USB_TYPE
+
+**Description:**
+
+Define Teensy 3.1 usb device type. Available options are: 
+
+**Example:**
+
+```Makefile
+USB_TYPE = USB_SERIAL
+# or
+USB_TYPE = USB_HID
+# or
+USB_TYPE = USB_SERIAL_HID
+# or
+USB_TYPE = USB_MIDI
+# or
+USB_TYPE = USB_RAWHID
+# or
+USB_TYPE = USB_FLIGHTSIM
+```
+
+**Requirement:** *Optional*
+
+----
+
 ### USB_VID
 
 **Description:**

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -456,7 +456,7 @@ VARIANT = leonardo
 
 **Description:**
 
-Define Teensy 3.1 usb device type. Available options are: 
+Define Teensy 3.1 usb device type. Default is USB_SERIAL
 
 **Example:**
 


### PR DESCRIPTION
This revised version of the Teensy.mk Makefile exposes the type of usb device that you would like to configure the Teensy to be in the top-level "short" Makefile.

Users can now specify (in their Makefile)
USB_TYPE = USB_RAWHID
or the other types.

If no type is specified, the default is USB_SERIAL.