### PR TITLE
Updated Fedora spec file

### DIFF
--- a/packaging/fedora/arduino-mk.spec
+++ b/packaging/fedora/arduino-mk.spec
@@ -1,13 +1,12 @@
 Name:			arduino-mk
 Version:		1.3.4
-Release:		1%{dist}
+Release:		2%{dist}
 Summary:		Program your Arduino from the command line
 Packager:		Simon John <git@the-jedi.co.uk>
 URL:            https://github.com/sudar/Arduino-Makefile
 Source:         %{name}-%{version}.tar.gz
 Group:			Development/Tools
 License:		LGPLv2+
-BuildRoot:		%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:		noarch
 Requires:		arduino-core pyserial
 BuildRequires:	arduino-core
@@ -28,13 +27,11 @@ Arduino platform.
 mkdir -p %{buildroot}/%{_datadir}/arduino
 mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_mandir}/man1
-mkdir -p %{buildroot}/%{_docdir}/%{name}/examples
-install -m 755 -d %{buildroot}/%{_docdir}/%{name}
-install -m 755 -d %{buildroot}/%{_docdir}/%{name}/examples
-for dir in `find examples -type d` ; do install -m 755 -d %{buildroot}/%{_docdir}/%{name}/$dir ; done
-for file in `find examples -type f ! -name .gitignore` ; do install -m 644 $file %{buildroot}/%{_docdir}/%{name}/$file ; done
+mkdir -p %{buildroot}/%{_pkgdocdir}/examples
+for dir in `find examples -type d` ; do install -m 755 -d %{buildroot}/%{_pkgdocdir}/$dir ; done
+for file in `find examples -type f ! -name .gitignore` ; do install -m 644 $file %{buildroot}/%{_pkgdocdir}/$file ; done
 install -m 644 *.mk arduino-mk-vars.md %{buildroot}/%{_datadir}/arduino
-install -m 644 licence.txt %{buildroot}/%{_docdir}/%{name}
+install -m 644 licence.txt %{buildroot}/%{_pkgdocdir}
 install -m 755 bin/ard-reset-arduino %{buildroot}/%{_bindir}/ard-reset-arduino
 install -m 644 ard-reset-arduino.1 %{buildroot}/%{_mandir}/man1
 
@@ -47,11 +44,13 @@ rm -rf %{buildroot}
 %{_mandir}/man1/ard-reset-arduino.1*
 %{_datadir}/arduino/*.mk
 %{_datadir}/arduino/arduino-mk-vars.md
-%doc %{_docdir}/%{name}/licence.txt
-%docdir %{_docdir}/%{name}/examples
-%{_docdir}/%{name}/examples
+%doc %{_pkgdocdir}/licence.txt
+%doc %{_pkgdocdir}/examples
 
 %changelog
+* Sat Jan 10 2015 Suvayu Ali <fatkasuvayu+linux@gmail.com>
+- Update according to latest Fedora packaging guidelines
+
 * Sat Apr 12 2014 Simon John <git@the-jedi.co.uk>
 - Put manpage back.
 * Fri Apr 04 2014 Simon John <git@the-jedi.co.uk>

--- a/packaging/fedora/arduino-mk.spec
+++ b/packaging/fedora/arduino-mk.spec
@@ -1,6 +1,6 @@
 Name:			arduino-mk
 Version:		1.3.4
-Release:		2%{dist}
+Release:		3%{dist}
 Summary:		Program your Arduino from the command line
 Packager:		Simon John <git@the-jedi.co.uk>
 URL:            https://github.com/sudar/Arduino-Makefile
@@ -35,6 +35,11 @@ install -m 644 licence.txt %{buildroot}/%{_pkgdocdir}
 install -m 755 bin/ard-reset-arduino %{buildroot}/%{_bindir}/ard-reset-arduino
 install -m 644 ard-reset-arduino.1 %{buildroot}/%{_mandir}/man1
 
+# Fedora uses ccache
+sed -i -e 's,\(CC \+= \)\($(AVR_TOOLS_PATH)\)\(/$(CC_NAME)\),\1%{_libdir}/ccache\3,' \
+    -e 's,\(CXX \+= \)\($(AVR_TOOLS_PATH)\)\(/$(CXX_NAME)\),\1%{_libdir}/ccache\3,' \
+    %{buildroot}/%{_datadir}/arduino/Arduino.mk
+
 %clean
 rm -rf %{buildroot}
 
@@ -48,6 +53,9 @@ rm -rf %{buildroot}
 %doc %{_pkgdocdir}/examples
 
 %changelog
+* Sun Feb 22 2015 Suvayu Ali <fatkasuvayu+linux@gmail.com> - 1.3.4-3
+- Use ccache for compilers
+
 * Sat Jan 10 2015 Suvayu Ali <fatkasuvayu+linux@gmail.com>
 - Update according to latest Fedora packaging guidelines
 


### PR DESCRIPTION
Hi,

I updated the Fedora spec file as per latest Fedora packaging guidelines.  And made the necessary changes so `ccache` is used.  I have a test build here: https://copr.fedoraproject.org/coprs/fatka/arduino-mk/build/69001/.  Please feel free to give any feedback.

Cheers,