### PR TITLE
Add "linuxgpio" to the list of ISP's that don't have a port

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1342,7 +1342,7 @@ endif
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
 ifndef $(ISP_PORT)
-    ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio avrispmkii))
+    ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio linuxgpio avrispmkii))
         AVRDUDE_ISP_OPTS += -P $(call get_isp_port)
     endif
 else


### PR DESCRIPTION
Hi,

I've been using avrdude-6.1 (compiled from source with linuxgpio enabled) to program on the Raspberry Pi. When using 'make ispload', avrdude complains about the port. Just like these:

gpio pull request: https://github.com/sudar/Arduino-Makefile/pull/166
avrispmkii pull request: https://github.com/sudar/Arduino-Makefile/pull/282

Adding "linuxgpio" to the list of ISP's that don't have a port fixes the issue. Linuxgpio is now a built-in option in avrdude.

I would really appreciate it if you added it to your awesome Makefile. Thanks!