### PR TITLE
Added ARCHITECTURE to ALTERNATE_CORE_PATH to support 1.5+ cores

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -475,7 +475,7 @@ ifdef ALTERNATE_CORE
     $(call show_config_variable,ALTERNATE_CORE,[USER])
 
     ifndef ALTERNATE_CORE_PATH
-        ALTERNATE_CORE_PATH = $(ARDUINO_SKETCHBOOK)/hardware/$(ALTERNATE_CORE)
+        ALTERNATE_CORE_PATH = $(ARDUINO_SKETCHBOOK)/hardware/$(ALTERNATE_CORE)/$(ARCHITECTURE)
     endif
 endif
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Fix speed regression. Thanks ladislas (Issue #280) (https://github.com/sej7278)
 - Fix: Removed some double quotes that were breaking variable expansion. (https://github.com/sej7278)
 - Fix: Fixed PLATFORM_LIB support for 1.5+ and removed duplicate libs (https://github.com/sej7278)
+- Fix: Added ARCHITECTURE to ALTERNATE_CORE_PATH to support 1.5+ cores like arduino-tiny (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)


### PR DESCRIPTION
....like arduino-tiny.

arduino-tiny and damellis' attiny85 cores don't use a vendor, but they do use the avr architecture (subdirectory) in their 1.5/1.6 branches.

arduino-tiny builds and is auto-detected now using 1.6.1, still needs some work to support sub-cpu's and clocks.

damellis doesn't compile, but that's not our makefile it seems.

1.0-only cores like the sparkfun pro micro don't break on 1.0 ide (nor do 1.0 versions of the above attiny85 cores).