### PR TITLE
Added BOARD_SUB to OBJDIR

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -688,6 +688,9 @@ endif
 # Everything gets built in here (include BOARD_TAG now)
 ifndef OBJDIR
     OBJDIR = build-$(BOARD_TAG)
+    ifdef BOARD_SUB
+        OBJDIR = build-$(BOARD_TAG)-$(BOARD_SUB)
+    endif
     $(call show_config_variable,OBJDIR,[COMPUTED],(from BOARD_TAG))
 else
     $(call show_config_variable,OBJDIR,[USER])

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,6 +29,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Replace CXX_NAME with CXX as per the Emacs Flymake Wiki (Issue #309) (https://github.com/sej7278)
 - Tweak: Ability to override `USB_TYPE` in Teensy.md (Issue #313) (https://github.com/Poofjunior)
 - Tweak: Integration instructions for CodeBlocks IDE (Issue #321) (https://github.com/fbielejec)
+- Tweak: Add BOARD_SUB to OBJDIR if defined in 1.5+ (https://github.com/sej7278)
 
 - Fix: Improved Windows (Cygwin/MSYS) support (https://github.com/PeterMosmans)
 - Fix: Change "tinyladi" username to "ladislas" in HISTORY.md. (https://github.com/ladislas)


### PR DESCRIPTION
So that when changing sub boards we don't accidentally overwrite existing builds.

E.g. mega1280 and mega2560 previously *both* created a "build-mega" directory, now they'll create build-mega-mega2560 and build-mega-mega1280

Only applies to 1.5+ of course, and only when BOARD_SUB is used. 1.0 will still create build-mega2560 and build-mega1280 directories (just BOARD_TAG)

Also, OBJDIR is still completely user-overridable, we're not forcing the build-TAG-SUB format on them