### PR TITLE
Add = to PARSE_BOARD regex to make it less greedy.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -552,7 +552,7 @@ endif
 
 ifndef PARSE_BOARD
     # result = $(call READ_BOARD_TXT, 'boardname', 'parameter')
-    PARSE_BOARD = $(shell grep -v '^\#' $(BOARDS_TXT) | grep $(1).$(2) | cut -d = -f 2 )
+    PARSE_BOARD = $(shell grep -v '^\#' $(BOARDS_TXT) | grep $(1).$(2)= | cut -d = -f 2 )
 endif
 
 # If NO_CORE is set, then we don't have to parse boards.txt file

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -329,10 +329,16 @@ endif
 
 ifndef ARDUINO_SKETCHBOOK
     ifndef ARDUINO_PREFERENCES_PATH
+        ifeq ($(shell expr $(ARDUINO_VERSION) '>' 150), 1)
+            AUTO_ARDUINO_PREFERENCES := $(firstword \
+                $(call dir_if_exists,$(HOME)/.arduino15/preferences.txt) )
+                # TODO: add mac/windows version once known
+        else
+            AUTO_ARDUINO_PREFERENCES := $(firstword \
+                $(call dir_if_exists,$(HOME)/.arduino/preferences.txt) \
+                $(call dir_if_exists,$(HOME)/Library/Arduino/preferences.txt) )
+        endif
 
-        AUTO_ARDUINO_PREFERENCES := $(firstword \
-            $(call dir_if_exists,$(HOME)/.arduino/preferences.txt) \
-            $(call dir_if_exists,$(HOME)/Library/Arduino/preferences.txt) )
         ifdef AUTO_ARDUINO_PREFERENCES
            ARDUINO_PREFERENCES_PATH = $(AUTO_ARDUINO_PREFERENCES)
            $(call show_config_variable,ARDUINO_PREFERENCES_PATH,[AUTODETECTED])

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Ability to override `USB_TYPE` in Teensy.md (Issue #313) (https://github.com/Poofjunior)
 - Tweak: Integration instructions for CodeBlocks IDE (Issue #321) (https://github.com/fbielejec)
 - Tweak: Add BOARD_SUB to OBJDIR if defined in 1.5+ (https://github.com/sej7278)
+- Tweak: Add = to PARSE_BOARD regex to make it less greedy and not match vid.0, vid.1 and vid (https://github.com/sej7278)
 
 - Fix: Improved Windows (Cygwin/MSYS) support (https://github.com/PeterMosmans)
 - Fix: Change "tinyladi" username to "ladislas" in HISTORY.md. (https://github.com/ladislas)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -48,6 +48,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Removed some double quotes that were breaking variable expansion. (https://github.com/sej7278)
 - Fix: Fixed PLATFORM_LIB support for 1.5+ and removed duplicate libs (https://github.com/sej7278)
 - Fix: Added ARCHITECTURE to ALTERNATE_CORE_PATH to support 1.5+ cores like arduino-tiny (https://github.com/sej7278)
+- Fix: Can now find IDE 1.5+ preferences.txt on Linux at least (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)


### PR DESCRIPTION
For instance in the Sparkfun 1.6 core, we have:

```
  promicro16.build.vid.0=0x1B4F
  promicro16.build.vid.1=0x1B4F
  promicro16.build.vid=0x1B4F
```

So we end up matching all 3 instead of just the last one.

Adding the = means we're looking for ```promicro16.build.vid=``` so not catching the .0 or .1 version.

Probably needs some good discussion as its quite an important function, but I can't really see it breaking things as we already pipe to ```cut -d =```, the only possibility is if there's whitespace around the = i guess, but not sure that's a valid boards.txt entry then anyway.

See details about multiple usb vid/pid's here: https://github.com/arduino/Arduino/wiki/Arduino-Hardware-Cores-migration-guide-from-1.0-to-1.6#step-6-add-usb-identifiers-for-port-list-menu