### PR TITLE
Added support for VARIANT in submenu's

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -577,7 +577,14 @@ ifeq ($(strip $(NO_CORE)),)
 
     # Which variant ? This affects the include path
     ifndef VARIANT
-        VARIANT = $(call PARSE_BOARD,$(BOARD_TAG),build.variant)
+        VARIANT := $(call PARSE_BOARD,$(BOARD_TAG),build.variant)
+        ifndef VARIANT
+            # might be a submenu
+            VARIANT := $(call PARSE_BOARD,$(BOARD_TAG),menu.cpu.$(BOARD_SUB).build.variant)
+        endif
+        $(call show_config_variable,VARIANT,[COMPUTED],(from build.variant))
+    else
+        $(call show_config_variable,VARIANT,[USER])
     endif
 
     # see if we are a caterina device like leonardo or micro

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Integration instructions for CodeBlocks IDE (Issue #321) (https://github.com/fbielejec)
 - Tweak: Add BOARD_SUB to OBJDIR if defined in 1.5+ (https://github.com/sej7278)
 - Tweak: Add = to PARSE_BOARD regex to make it less greedy and not match vid.0, vid.1 and vid (https://github.com/sej7278)
+- Tweak: Added note about clock submenu's being used as F_CPU (https://github.com/sej7278)
 
 - Fix: Improved Windows (Cygwin/MSYS) support (https://github.com/PeterMosmans)
 - Fix: Change "tinyladi" username to "ladislas" in HISTORY.md. (https://github.com/ladislas)
@@ -49,6 +50,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Fixed PLATFORM_LIB support for 1.5+ and removed duplicate libs (https://github.com/sej7278)
 - Fix: Added ARCHITECTURE to ALTERNATE_CORE_PATH to support 1.5+ cores like arduino-tiny (https://github.com/sej7278)
 - Fix: Can now find IDE 1.5+ preferences.txt on Linux and Mac (https://github.com/sej7278)
+- Fix: Added support for VARIANT being a submenu item in 1.6 cores like attiny (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -51,6 +51,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Added ARCHITECTURE to ALTERNATE_CORE_PATH to support 1.5+ cores like arduino-tiny (https://github.com/sej7278)
 - Fix: Can now find IDE 1.5+ preferences.txt on Linux and Mac (https://github.com/sej7278)
 - Fix: Added support for VARIANT being a submenu item in 1.6 cores like attiny (https://github.com/sej7278)
+- Fix: Replaced copyright symbol causing sed problems on OSX (Issue #335). (https://github.com/sej7278)
 
 ### 1.3.4 (2014-07-12)
 - Tweak: Allow spaces in "Serial.begin (....)". (Issue #190) (https://github.com/pdav)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -520,7 +520,8 @@ USB_PID = 0x8039
 
 CPU speed in Hz
 
-Usually can be auto-detected as `build.f_cpu` from `boards.txt`
+Usually can be auto-detected as `build.f_cpu` from `boards.txt`, except in
+some 1.6 cores like attiny where there is a clock submenu.
 
 **Example:**
 

--- a/examples/BlinkInAVRC/blink.c
+++ b/examples/BlinkInAVRC/blink.c
@@ -1,5 +1,5 @@
 /*
- * © Anil Kumar Pugalia, 2010. Email: email@sarika-pugs.com
+ * (c) Anil Kumar Pugalia, 2010. Email: email@sarika-pugs.com
  *
  * ATmega48/88/168, ATmega16/32
  * 


### PR DESCRIPTION
Also added a note that in certain 1.6 cores (attiny) ```F_CPU``` is a submenu item e.g. 

```
attiny.menu.clock.internal1.build.f_cpu=1000000L
```
