### PR TITLE
Replaced sub-make with function calls

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1406,39 +1406,47 @@ $(TARGET_ELF): 	$(LOCAL_OBJS) $(CORE_LIB) $(OTHER_OBJS)
 $(CORE_LIB):	$(CORE_OBJS) $(LIB_OBJS) $(PLATFORM_LIB_OBJS) $(USER_LIB_OBJS)
 		$(AR) rcs $@ $(CORE_OBJS) $(LIB_OBJS) $(PLATFORM_LIB_OBJS) $(USER_LIB_OBJS)
 
-error_on_caterina:
-		$(ERROR_ON_CATERINA)
+error_on_caterina: $(call error_on_caterina)
 
+error_on_caterina =	$(ERROR_ON_CATERINA)
 
 # Use submake so we can guarantee the reset happens
 # before the upload, even with make -j
 upload:		$(TARGET_HEX) verify_size
-		$(MAKE) reset
-		$(MAKE) do_upload
+		$(call reset)
+		$(call do_upload)
 
 raw_upload:	$(TARGET_HEX) verify_size
-		$(MAKE) error_on_caterina
-		$(MAKE) do_upload
+		$(call error_on_caterina)
+		$(call do_upload)
 
 do_upload:
-		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ARD_OPTS) \
+		$(call do_upload)
+
+do_upload =	$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ARD_OPTS) \
 			$(AVRDUDE_UPLOAD_HEX)
 
-do_eeprom:	$(TARGET_EEP) $(TARGET_HEX)
-		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ARD_OPTS) \
+do_eeprom:
+		$(call do_eeprom)
+
+do_eeprom =	$(TARGET_EEP) $(TARGET_HEX) \
+			$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ARD_OPTS) \
 			$(AVRDUDE_UPLOAD_EEP)
 
 eeprom:		$(TARGET_HEX) verify_size
-		$(MAKE) reset
-		$(MAKE) do_eeprom
+		$(call reset)
+		$(call do_eeprom)
 
 raw_eeprom:	$(TARGET_HEX) verify_size
-		$(MAKE) error_on_caterina
-		$(MAKE) do_eeprom
+		$(call error_on_caterina)
+		$(call do_eeprom)
 
 reset:
-		$(call arduino_output,Resetting Arduino...)
+		$(call reset)
+
+reset =	$(call arduino_output,Resetting Arduino...) \
 		$(RESET_CMD)
+
 
 # stty on MacOS likes -F, but on Debian it likes -f redirecting
 # stdin/out appears to work but generates a spurious error on MacOS at


### PR DESCRIPTION
By not using sub-make but function calls one is able to use this as a global makefile.

Let's say you want to use this makefile in a script or app and don't want to have a makefile in every project folder.
This could be done like this:

```
# Set environment variables
$ cd ~/my-arduino-project
$ make -f ~/Arduino-makefile/Arduino.mk
```

But using `upload` isn't working because it's using sub-make:

```
$ make -f ~/Arduino-makefile/Arduino.mk upload
make[1]: *** No rule to make target `reset'.  Stop.
make: *** [upload] Error 2
```

Is the use of sub-make appropriate here? Because no separate makefile is used.

https://www.gnu.org/software/make/manual/html_node/Recursion.html

> This technique is useful when you want separate makefiles for various subsystems that compose a larger system. For example, suppose you have a subdirectory ‘subdir’ which has its own makefile, and you would like the containing directory’s makefile to run make on the subdirectory.
> 
> subsystem:
> &nbsp;&nbsp;&nbsp;&nbsp;cd subdir && $(MAKE)

The problem is that the -f flag isn't passed down, which makes sense if you use sub-make for separate makefiles.

https://www.gnu.org/software/make/manual/html_node/Options_002fRecursion.html

> The options ‘-C’, ‘-f’, ‘-o’, and ‘-W’ are not put into MAKEFLAGS; these options are not passed down.

My suggestion is to use functions instead of sub-make.
I'm aware that this is a specific problem and maybe there is a cleaner solution.
