### PR TITLE
Better autodetection of ARDUINO_SKETCHBOOK and ARDUINO_DIR on OSX

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -357,7 +357,9 @@ ifndef ARDUINO_SKETCHBOOK
     ifneq ($(ARDUINO_SKETCHBOOK),)
         $(call show_config_variable,ARDUINO_SKETCHBOOK,[AUTODETECTED],(from arduino preferences file))
     else
-        ARDUINO_SKETCHBOOK := $(HOME)/sketchbook
+        ARDUINO_SKETCHBOOK := $(firstword \
+            $(call dir_if_exists,$(HOME)/sketchbook) \
+            $(call dir_if_exists,$(HOME)/Documents/Arduino) )
         $(call show_config_variable,ARDUINO_SKETCHBOOK,[DEFAULT])
     endif
 else

--- a/Common.mk
+++ b/Common.mk
@@ -68,7 +68,8 @@ endif
 ifndef ARDUINO_DIR
     AUTO_ARDUINO_DIR := $(firstword \
         $(call dir_if_exists,/usr/share/arduino) \
-        $(call dir_if_exists,/Applications/Arduino.app/Contents/Resources/Java) )
+        $(call dir_if_exists,/Applications/Arduino.app/Contents/Resources/Java) \
+        $(call dir_if_exists,/Applications/Arduino.app/Contents/Java) )
     ifdef AUTO_ARDUINO_DIR
        ARDUINO_DIR = $(AUTO_ARDUINO_DIR)
        $(call show_config_variable,ARDUINO_DIR,[AUTODETECTED])

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Add BOARD_SUB to OBJDIR if defined in 1.5+ (https://github.com/sej7278)
 - Tweak: Add = to PARSE_BOARD regex to make it less greedy and not match vid.0, vid.1 and vid (https://github.com/sej7278)
 - Tweak: Added note about clock submenu's being used as F_CPU (https://github.com/sej7278)
+- Tweak: Better autodetection of ARDUINO_SKETCHBOOK and ARDUINO_DIR on OSX (https://github.com/sej7278)
 
 - Fix: Improved Windows (Cygwin/MSYS) support (https://github.com/PeterMosmans)
 - Fix: Change "tinyladi" username to "ladislas" in HISTORY.md. (https://github.com/ladislas)


### PR DESCRIPTION
Added 1.6 path for ARDUINO_DIR and also a better OSX default for ARDUINO_SKETCHBOOK than just the Linux $(HOME)/sketchbook

So we can now just have a Makefile consisting of:

```
BOARD_TAG = uno 
MONITOR_PORT = /dev/ttyACM0

include $(HOME)/arduino-mk/Arduino-Makefile/Arduino.mk
```

And you don't need to run the IDE to create preferences.txt to find the sketchbook location (if you use the default).