### PR TITLE
Fix reset for leonardo

### DIFF
--- a/bin/ard-reset-arduino
+++ b/bin/ard-reset-arduino
@@ -17,10 +17,10 @@ if args.caterina:
     if args.verbose: print('Forcing reset using 1200bps open/close on port %s' % args.port[0])
     ser = serial.Serial(args.port[0], 57600)
     ser.close()
-    ser.open()
-    ser.close()
     ser.setBaudrate(1200)
     ser.open()
+    ser.setRTS(True)  # RTS line needs to be held high and DTR low
+    ser.setDTR(False) # (see Arduino IDE source code)
     ser.close()
     sleep(1)
 


### PR DESCRIPTION
I found that the previous reset code did not work for Leonardo or Micro, nor did any reset code anywhere on the internet.

An examination of the Arduino IDE source code (and the JNI code behind its serial implementation) shows that it holds RTS high and DTR low when doing the 1200 baud open/close. And it turns out that's exactly what's needed!