### PR TITLE
Add support for attiny84a

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1282,8 +1282,8 @@ ifndef AVRDUDE_OPTS
     AVRDUDE_OPTS = -q -V
 endif
 
-# Avrdude uses mcu attiny84 to upload to the attiny84a, but we want to be able to set
-# the gcc mmcu flag to attiny84a.
+# Decouple the mcu between the compiler options (-mmcu) and the avrdude options (-p).
+# This is needed to be able to compile for attiny84a but specify the upload mcu as attiny84.
 ifeq ($(MCU), attiny84a)
   AVRDUDE_MCU = attiny84
 else

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1290,21 +1290,14 @@ ifndef AVRDUDE_MCU
   AVRDUDE_MCU = $(MCU)
 endif
 
-# -D - Disable auto erase for flash memory
-# -D is needed for Mega boards. (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
-# -D must NOT be present for attiny84a (unknown for attiny84)
-ifeq ($(AVRDUDE_MCU), attiny84)
-    AVRDUDE_ERASE_FLASH_OPT =
-else
-    AVRDUDE_ERASE_FLASH_OPT = -D
-endif
-
-AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) $(AVRDUDE_ERASE_FLASH_OPT) -p $(AVRDUDE_MCU)
+AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) -p $(AVRDUDE_MCU)
 ifdef AVRDUDE_CONF
     AVRDUDE_COM_OPTS += -C $(AVRDUDE_CONF)
 endif
 
-AVRDUDE_ARD_OPTS = -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
+# -D - Disable auto erase for flash memory
+# -D is needed for Mega boards. (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
+AVRDUDE_ARD_OPTS = -D -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
 ifeq ($(CURRENT_OS), WINDOWS)
     # get_monitor_port checks to see if the monitor port exists, assuming it is
     # a file. In Windows, avrdude needs the port in the format 'com1' which is
@@ -1368,6 +1361,7 @@ ifndef AVRDUDE_ISP_FUSES_POST
     endif
 endif
 
+# -D may cause issues with some boards like attiny84a.
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
 ifndef $(ISP_PORT)

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1282,14 +1282,26 @@ ifndef AVRDUDE_OPTS
     AVRDUDE_OPTS = -q -V
 endif
 
-AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) -p $(MCU)
+# We avrdude uses attiny84 to upload to the 84a, but we want to be able to set the gcc mmcu flag to attiny84a.
+ifeq ($(MCU), attiny84a)
+  AVRDUDE_MCU = attiny84
+else
+  AVRDUDE_MCU = $(MCU)
+endif
+
+# -D - Disable auto erase for flash memory
+# -D is needed for Mega boards. (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
+# -D must not be present for attiny84a (unknown for attiny84)
+ifneq ($(AVRDUDE_MCU), attiny84)
+    AVRDUDE_OPTS += -D
+endif
+
+AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) -p $(AVRDUDE_MCU)
 ifdef AVRDUDE_CONF
     AVRDUDE_COM_OPTS += -C $(AVRDUDE_CONF)
 endif
 
-# -D - Disable auto erase for flash memory
-# (-D is needed for Mega boards. See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
-AVRDUDE_ARD_OPTS = -D -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
+AVRDUDE_ARD_OPTS = -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
 ifeq ($(CURRENT_OS), WINDOWS)
     # get_monitor_port checks to see if the monitor port exists, assuming it is
     # a file. In Windows, avrdude needs the port in the format 'com1' which is

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1296,7 +1296,8 @@ ifdef AVRDUDE_CONF
 endif
 
 # -D - Disable auto erase for flash memory
-# -D is needed for Mega boards. (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
+# Note: -D is needed for Mega boards.
+#       (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
 AVRDUDE_ARD_OPTS = -D -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
 ifeq ($(CURRENT_OS), WINDOWS)
     # get_monitor_port checks to see if the monitor port exists, assuming it is
@@ -1361,7 +1362,9 @@ ifndef AVRDUDE_ISP_FUSES_POST
     endif
 endif
 
-# -D may cause issues with some boards like attiny84a.
+# Note: setting -D to disable flash erase before programming may cause issues
+# with some boards like attiny84a, making the program not "take",
+# so we do not set it by default.
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
 ifndef $(ISP_PORT)

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1282,7 +1282,8 @@ ifndef AVRDUDE_OPTS
     AVRDUDE_OPTS = -q -V
 endif
 
-# We avrdude uses attiny84 to upload to the 84a, but we want to be able to set the gcc mmcu flag to attiny84a.
+# Avrdude uses mcu attiny84 to upload to the attiny84a, but we want to be able to set
+# the gcc mmcu flag to attiny84a.
 ifeq ($(MCU), attiny84a)
   AVRDUDE_MCU = attiny84
 else

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1284,20 +1284,22 @@ endif
 
 # Decouple the mcu between the compiler options (-mmcu) and the avrdude options (-p).
 # This is needed to be able to compile for attiny84a but specify the upload mcu as attiny84.
-ifeq ($(MCU), attiny84a)
-  AVRDUDE_MCU = attiny84
-else
+# We default to picking the -mmcu flag, but you can override this by setting
+# AVRDUDE_MCU in your makefile.
+ifndef AVRDUDE_MCU
   AVRDUDE_MCU = $(MCU)
 endif
 
 # -D - Disable auto erase for flash memory
 # -D is needed for Mega boards. (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
-# -D must not be present for attiny84a (unknown for attiny84)
-ifneq ($(AVRDUDE_MCU), attiny84)
-    AVRDUDE_OPTS += -D
+# -D must NOT be present for attiny84a (unknown for attiny84)
+ifeq ($(AVRDUDE_MCU), attiny84)
+    AVRDUDE_ERASE_FLASH_OPT =
+else
+    AVRDUDE_ERASE_FLASH_OPT = -D
 endif
 
-AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) -p $(AVRDUDE_MCU)
+AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) $(AVRDUDE_ERASE_FLASH_OPT) -p $(AVRDUDE_MCU)
 ifdef AVRDUDE_CONF
     AVRDUDE_COM_OPTS += -C $(AVRDUDE_CONF)
 endif

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Support for PuTTY under Windows (https://github.com/PeterMosmans)
 - New: Add support for installation using homebrew(https://github.com/ladislas)
 - New: Add support and example for flashing on a remote RPi. (https://github.com/Gaboose)
+- New: Add option to split avrdude MCU from avr-gcc MCU (Issue #357) (https://github.com/hhgarnes)
 - Tweak: Update Makefile-example.mk with STD flags (https://github.com/ladislas)
 - Tweak: Allow remove of any OBJDIR with `$(REMOVE) $(OBJDIR)`. (https://github.com/ladislas)
 - Tweak: Add cpp to extensions supported by "make generate_assembly". (https://github.com/sej7278)


### PR DESCRIPTION
Attiny84a requires two things:
-Support for rewriting the avrdude mcu to attiny84 even if the gcc mmcu parameter stays as attiny84a
-Removal of the avrdude -D flag. Without this, no uploaded sketch would ever take on the attiny84a (determined by experimentation and comparison of parameters with the arduino ide)