### PR TITLE
Decouple the mcu flag between gcc and avrdude

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1282,13 +1282,22 @@ ifndef AVRDUDE_OPTS
     AVRDUDE_OPTS = -q -V
 endif
 
-AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) -p $(MCU)
+# Decouple the mcu between the compiler options (-mmcu) and the avrdude options (-p).
+# This is needed to be able to compile for attiny84a but specify the upload mcu as attiny84.
+# We default to picking the -mmcu flag, but you can override this by setting
+# AVRDUDE_MCU in your makefile.
+ifndef AVRDUDE_MCU
+  AVRDUDE_MCU = $(MCU)
+endif
+
+AVRDUDE_COM_OPTS = $(AVRDUDE_OPTS) -p $(AVRDUDE_MCU)
 ifdef AVRDUDE_CONF
     AVRDUDE_COM_OPTS += -C $(AVRDUDE_CONF)
 endif
 
 # -D - Disable auto erase for flash memory
-# (-D is needed for Mega boards. See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
+# Note: -D is needed for Mega boards.
+#       (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
 AVRDUDE_ARD_OPTS = -D -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
 ifeq ($(CURRENT_OS), WINDOWS)
     # get_monitor_port checks to see if the monitor port exists, assuming it is
@@ -1353,6 +1362,9 @@ ifndef AVRDUDE_ISP_FUSES_POST
     endif
 endif
 
+# Note: setting -D to disable flash erase before programming may cause issues
+# with some boards like attiny84a, making the program not "take",
+# so we do not set it by default.
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
 ifndef $(ISP_PORT)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Various spelling/grammar/typo fixes (https://github.com/dcousens)
 - Tweak: Clarified some 1.5+ issues in docs (Issue #352) (https://github.com/sej7278)
 - Tweak: Added some more Continuous Integration tests (https://github.com/sej7278)
+- New: Add option to split avrdude MCU from avr-gcc MCU (Issue #357) (https://github.com/hhgarnes)
 
 ### 1.5 (2015-04-07)
 - New: Add support for new 1.5.x library layout (Issue #275) (https://github.com/lukasz-e)


### PR DESCRIPTION
Add support for decoupling the mcu flag between gcc and avrdude, which is for example useful if you want to compile with the mcu specified as attiny84a but upload with avrdude using mcu attiny84 (avrdude doesn't support such detailed chip specifications)

Also add some comments about interactions with attiny84a and avrdude's -D option, which can cause uploads to the chip through ArduinoISP to fail.