### PR TITLE
Updated instructions for Fedora 22

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,13 +6,14 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 
 ### In Development
 
+- New: Add option to split avrdude MCU from avr-gcc MCU (Issue #357) (https://github.com/hhgarnes)
 - New: Add support for /dev/tty.wchusbserial* (comes with cheap clones - DCCduino) (https://github.com/biesiad)
 - New: Add support for picocom as serial monitor(https://github.com/biesiad)
 - Tweak: Looks for submenu items first when parsing BOARDS_TXT (Issue #347) (https://github.com/sej7278)
 - Tweak: Various spelling/grammar/typo fixes (https://github.com/dcousens)
 - Tweak: Clarified some 1.5+ issues in docs (Issue #352) (https://github.com/sej7278)
 - Tweak: Added some more Continuous Integration tests (https://github.com/sej7278)
-- New: Add option to split avrdude MCU from avr-gcc MCU (Issue #357) (https://github.com/hhgarnes)
+- Tweak: Updated Fedora instructions (https://github.com/sej7278)
 
 ### 1.5 (2015-04-07)
 - New: Add support for new 1.5.x library layout (Issue #275) (https://github.com/lukasz-e)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ On Fedora:
 
 ```sh
 yum install pyserial
+
+# or on Fedora 22+
+
+dnf install pyserial
 ```
 
 On openSUSE:

--- a/packaging/fedora/README.md
+++ b/packaging/fedora/README.md
@@ -2,7 +2,13 @@
 
 First install the dependencies as root:
 
+```sh
     yum install arduino-core rpm-build
+
+    # or on Fedora 22+
+
+    dnf install arduino-core rpmdevtools
+```
 
 From the top-level Arduino-Makefile directory you've checked out of github, run the following (as unprivileged user) to create a compressed tarball using the naming conventions required by rpmbuild:
 


### PR DESCRIPTION
Minor changes to reflect new rpmbuild package name and yum is now replaced by dnf