### PR TITLE
Added support for AVR Dragon in both ISP and DebugWire mode

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1370,7 +1370,7 @@ endif
 AVRDUDE_ISP_OPTS = -c $(ISP_PROG) -b $(AVRDUDE_ISP_BAUDRATE)
 
 ifndef $(ISP_PORT)
-    ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio linuxgpio avrispmkii))
+    ifneq ($(strip $(ISP_PROG)),$(filter $(ISP_PROG), usbasp usbtiny gpio linuxgpio avrispmkii dragon_isp dragon_dw))
         AVRDUDE_ISP_OPTS += -P $(call get_isp_port)
     endif
 else


### PR DESCRIPTION
Adds support for
`ISP_PROG = dragon_isp`
and
`ISP_PROG = dragon_dw`

ISP mode is reasonable to add, but I think there might be a question as to whether DebugWire mode is appropriate. There might be some confusion since the makefile command is `make ispload` while the programmer would be using DebugWire.

I hope I'm doing this right. This is my first pull request.
Thanks for all your work.