### PR TITLE
Make sure TARGET is set correctly when CURDIR contains spaces.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -266,7 +266,9 @@ endif
 # Default TARGET to pwd (ex Daniele Vergini)
 
 ifndef TARGET
-    TARGET  = $(notdir $(CURDIR))
+    space :=
+    space +=
+    TARGET = $(notdir $(subst $(space),_,$(CURDIR)))
 endif
 
 ########################################################################

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Added some more Continuous Integration tests (https://github.com/sej7278)
 - Tweak: Updated Fedora instructions (https://github.com/sej7278)
 - Fix: Preserve original extension for object files, support asm sources in core, fixes pulseInASM (Issue #255, #364) (https://github.com/sej7278)
+- Fix: Make sure TARGET is set correctly when CURDIR contains spaces.
 
 ### 1.5 (2015-04-07)
 - New: Add support for new 1.5.x library layout (Issue #275) (https://github.com/lukasz-e)


### PR DESCRIPTION
With this fix the `TARGET` variable is set correctly when the project exists in
a path that contains spaces. So in this case:

    /Users/Joe/Dropbox (Personal)/example-project

`TARGET` will be set to `example-project` instead of `Dropbox example-project` (like it was
before this fix).