### PR TITLE
Ensure AVRDUDE_CONF is set when AVR_TOOLS_DIR is manually set

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -452,11 +452,12 @@ ifndef AVR_TOOLS_DIR
 else
     $(call show_config_variable,AVR_TOOLS_DIR,[USER])
 
-    # Check in Windows as Cygwin is being used, that the configuration file for the AVRDUDE is set
-    # Check if it works on MAC
-    ifeq ($(CURRENT_OS),WINDOWS)
-        ifndef AVRDUDE_CONF
-            AVRDUDE_CONF  = $(AVR_TOOLS_DIR)/etc/avrdude.conf
+    # ensure we can still find avrdude.conf
+    ifndef AVRDUDE_CONF
+        ifeq ($(shell expr $(ARDUINO_VERSION) '>' 157), 1)
+            AVRDUDE_CONF = $(AVR_TOOLS_DIR)/etc/avrdude.conf
+        else
+            AVRDUDE_CONF = $(AVR_TOOLS_DIR)/../avrdude.conf
         endif
     endif
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Updated Fedora instructions (https://github.com/sej7278)
 - Fix: Preserve original extension for object files, support asm sources in core, fixes pulseInASM (Issue #255, #364) (https://github.com/sej7278)
 - Fix: Make sure TARGET is set correctly when CURDIR contains spaces (https://github.com/svendahlstrand)
+- Fix: Ensure AVRDUDE_CONF is set when AVR_TOOLS_DIR is, not just on Windows (Issue #381) (https://github.com/sej7278)
 
 ### 1.5 (2015-04-07)
 - New: Add support for new 1.5.x library layout (Issue #275) (https://github.com/lukasz-e)


### PR DESCRIPTION
.....not just on Windows - fixes issue #381

Code around this area probably needs a tidy up at some point, seems like some duplication.

Also could do with checking on Cygwin.

Thanks @theicfire