### PR TITLE
Replace $VENDOR with $ARDMK_VENDOR

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -319,11 +319,11 @@ endif
 
 ########################################################################
 # 1.5.x vendor - defaults to arduino
-ifndef VENDOR
-	VENDOR = arduino
-    $(call show_config_variable,VENDOR,[DEFAULT])
+ifndef ARDMK_VENDOR
+	ARDMK_VENDOR = arduino
+    $(call show_config_variable,ARDMK_VENDOR,[DEFAULT])
 else
-    $(call show_config_variable,VENDOR,[USER])
+    $(call show_config_variable,ARDMK_VENDOR,[USER])
 endif
 
 ########################################################################
@@ -474,7 +474,7 @@ $(call show_config_variable,ARDUINO_LIB_PATH,[COMPUTED],(from ARDUINO_DIR))
 ifndef ARDUINO_PLATFORM_LIB_PATH
     ifeq ($(shell expr $(ARDUINO_VERSION) '>' 150), 1)
         # only for 1.5
-        ARDUINO_PLATFORM_LIB_PATH = $(ARDUINO_DIR)/hardware/$(VENDOR)/$(ARCHITECTURE)/libraries
+        ARDUINO_PLATFORM_LIB_PATH = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/$(ARCHITECTURE)/libraries
         $(call show_config_variable,ARDUINO_PLATFORM_LIB_PATH,[COMPUTED],(from ARDUINO_DIR))
     endif
 else
@@ -511,14 +511,14 @@ ifdef ALTERNATE_CORE_PATH
 else
 
     ifndef ARDUINO_VAR_PATH
-        ARDUINO_VAR_PATH  = $(ARDUINO_DIR)/hardware/$(VENDOR)/$(ARCHITECTURE)/variants
+        ARDUINO_VAR_PATH  = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/$(ARCHITECTURE)/variants
         $(call show_config_variable,ARDUINO_VAR_PATH,[COMPUTED],(from ARDUINO_DIR))
     else
         $(call show_config_variable,ARDUINO_VAR_PATH,[USER])
     endif
 
     ifndef BOARDS_TXT
-        BOARDS_TXT  = $(ARDUINO_DIR)/hardware/$(VENDOR)/$(ARCHITECTURE)/boards.txt
+        BOARDS_TXT  = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/$(ARCHITECTURE)/boards.txt
         $(call show_config_variable,BOARDS_TXT,[COMPUTED],(from ARDUINO_DIR))
     else
         $(call show_config_variable,BOARDS_TXT,[USER])
@@ -704,16 +704,16 @@ else
     $(call show_config_variable,OBJDIR,[USER])
 endif
 
-# Now that we have ARDUINO_DIR, VENDOR, ARCHITECTURE and CORE,
+# Now that we have ARDUINO_DIR, ARDMK_VENDOR, ARCHITECTURE and CORE,
 # we can set ARDUINO_CORE_PATH.
 ifndef ARDUINO_CORE_PATH
     ifeq ($(strip $(CORE)),)
-        ARDUINO_CORE_PATH = $(ARDUINO_DIR)/hardware/$(VENDOR)/$(ARCHITECTURE)/cores/arduino
+        ARDUINO_CORE_PATH = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/$(ARCHITECTURE)/cores/arduino
         $(call show_config_variable,ARDUINO_CORE_PATH,[DEFAULT])
     else
         ARDUINO_CORE_PATH = $(ALTERNATE_CORE_PATH)/cores/$(CORE)
         ifeq ($(wildcard $(ARDUINO_CORE_PATH)),)
-            ARDUINO_CORE_PATH = $(ARDUINO_DIR)/hardware/$(VENDOR)/$(ARCHITECTURE)/cores/$(CORE)
+            ARDUINO_CORE_PATH = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/$(ARCHITECTURE)/cores/$(CORE)
             $(call show_config_variable,ARDUINO_CORE_PATH,[COMPUTED],(from ARDUINO_DIR, BOARD_TAG and boards.txt))
         else
             $(call show_config_variable,ARDUINO_CORE_PATH,[COMPUTED],(from ALTERNATE_CORE_PATH, BOARD_TAG and boards.txt))
@@ -1121,7 +1121,7 @@ endif
 
 # either calculate parent dir from arduino dir, or user-defined path
 ifndef BOOTLOADER_PARENT
-    BOOTLOADER_PARENT = $(ARDUINO_DIR)/hardware/$(VENDOR)/$(ARCHITECTURE)/bootloaders
+    BOOTLOADER_PARENT = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/$(ARCHITECTURE)/bootloaders
     $(call show_config_variable,BOOTLOADER_PARENT,[COMPUTED],(from ARDUINO_DIR))
 else
     $(call show_config_variable,BOOTLOADER_PARENT,[USER])

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Preserve original extension for object files, support asm sources in core, fixes pulseInASM (Issue #255, #364) (https://github.com/sej7278)
 - Fix: Make sure TARGET is set correctly when CURDIR contains spaces (https://github.com/svendahlstrand)
 - Fix: Ensure AVRDUDE_CONF is set when AVR_TOOLS_DIR is, not just on Windows (Issue #381) (https://github.com/sej7278)
+- Fix: Rename VENDOR to ARDMK_VENDOR to workaround tcsh issue (Issue #386) (https://github.com/sej7278)
 
 ### 1.5 (2015-04-07)
 - New: Add support for new 1.5.x library layout (Issue #275) (https://github.com/lukasz-e)

--- a/Teensy.mk
+++ b/Teensy.mk
@@ -33,9 +33,9 @@ endif
 # include Common.mk now we know where it is
 include $(ARDMK_DIR)/Common.mk
 
-VENDOR              = teensy
+ARDMK_VENDOR        = teensy
 ARDUINO_CORE_PATH   = $(ARDUINO_DIR)/hardware/teensy/cores/teensy3
-BOARDS_TXT          = $(ARDUINO_DIR)/hardware/$(VENDOR)/boards.txt
+BOARDS_TXT          = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/boards.txt
 
 ifndef F_CPU
     F_CPU=96000000

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -166,7 +166,7 @@ ARCHITECTURE = sam
 
 ----
 
-### VENDOR
+### ARDMK_VENDOR
 
 **Description:**
 
@@ -177,7 +177,7 @@ Defaults to `arduino`
 **Example:**
 
 ```Makefile
-VENDOR = sparkfun
+ARDMK_VENDOR = sparkfun
 ```
 
 **Requirement:** *Optional*


### PR DESCRIPTION
....as ```VENDOR``` is a tcsh environment variable.

```ARCHITECTURE``` is probably safe as that's usually called ```ARCH```

Fixes issue #386.

Need to decide if this is going to upset too many user's who have already started using ```VENDOR``` - and who uses tcsh? ;-)