### PR TITLE
Better parsing of boards.txt file

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -568,7 +568,7 @@ endif
 
 ifndef PARSE_BOARD
     # result = $(call READ_BOARD_TXT, 'boardname', 'parameter')
-    PARSE_BOARD = $(shell grep -v '^\#' $(BOARDS_TXT) | grep $(1).$(2)= | cut -d = -f 2 )
+    PARSE_BOARD = $(shell grep -v '^\#' $(BOARDS_TXT) | grep "^[ \t]*$(1).$(2)=" | cut -d = -f 2)
 endif
 
 # If NO_CORE is set, then we don't have to parse boards.txt file

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,12 +6,12 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 
 ### In Development
 
-- Tweak: Add support for Adafruit trinket3/trinket5/protrinket3/protrinket5 by improved BOARDS_TXT parsing
 - New: Add AVR Dragon to list of ISP's without a port (https://github.com/mtnocean)
 - New: Add more board examples to Blink demo (https://github.com/sej7278)
 - New: Add option to split avrdude MCU from avr-gcc MCU (Issue #357) (https://github.com/hhgarnes)
 - New: Add support for /dev/tty.wchusbserial* (comes with cheap clones - DCCduino) (https://github.com/biesiad)
 - New: Add support for picocom as serial monitor (https://github.com/biesiad)
+- Tweak: Add support for Adafruit trinket3/trinket5/protrinket3/protrinket5 by improved BOARDS_TXT parsing (Issue #393) (https://github/com/zabereer)
 - Tweak: Looks for submenu items first when parsing BOARDS_TXT (Issue #347) (https://github.com/sej7278)
 - Tweak: Various spelling/grammar/typo fixes (https://github.com/dcousens)
 - Tweak: Clarified some 1.5+ issues in docs (Issue #352) (https://github.com/sej7278)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 
 ### In Development
 
+- Tweak: Add support for Adafruit trinket3/trinket5/protrinket3/protrinket5 by improved BOARDS_TXT parsing
 - New: Add AVR Dragon to list of ISP's without a port (https://github.com/mtnocean)
 - New: Add more board examples to Blink demo (https://github.com/sej7278)
 - New: Add option to split avrdude MCU from avr-gcc MCU (Issue #357) (https://github.com/hhgarnes)


### PR DESCRIPTION
The Adafruit boards.txt file contains trinket3, and protrinket3 which are both matched by the existing boards.txt parsing when specifying BOARD_TAG=trinket3.
This change anchors the grep regex matching to beginning of the line.
Thank you for a great Arduino makefile.