### PR TITLE
Removed the check for BOOTLOADER_PATH being empty

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1358,10 +1358,8 @@ endif
 
 # Bootloader file settings
 ifndef AVRDUDE_ISP_BURN_BOOTLOADER
-    ifneq ($(strip $(BOOTLOADER_PATH)),)
-        ifneq ($(strip $(BOOTLOADER_FILE)),)
-            AVRDUDE_ISP_BURN_BOOTLOADER += -U flash:w:$(BOOTLOADER_PARENT)/$(BOOTLOADER_PATH)/$(BOOTLOADER_FILE):i
-        endif
+    ifneq ($(strip $(BOOTLOADER_FILE)),)
+        AVRDUDE_ISP_BURN_BOOTLOADER += -U flash:w:$(BOOTLOADER_PARENT)/$(BOOTLOADER_PATH)/$(BOOTLOADER_FILE):i
     endif
 endif
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Rename VENDOR to ARDMK_VENDOR to workaround tcsh issue (Issue #386) (https://github.com/sej7278)
 - Fix: Document OSX 1.0/1.6 ARDUINO_DIR differences (https://github.com/thomaskilian)
 - Fix: Fix regex to support BOARD_TAGs with hyphens e.g. attiny44-20 (https://github.com/sej7278)
+- Fix: Remove check for BOOTLOADER_PATH, just check for BOOTLOADER_FILE (Issue #402) (https://github.com/sej7278)
 
 ### 1.5 (2015-04-07)
 - New: Add support for new 1.5.x library layout (Issue #275) (https://github.com/lukasz-e)


### PR DESCRIPTION
 as its merged into BOOTLOADER_FILE in 1.5+

Now we just check for BOOTLOADER_FILE being non-empty on both versions.

Fixes issue #402