### PR TITLE
Added target to display submenu options parsed out of boards.txt

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1495,6 +1495,9 @@ size:	$(TARGET_HEX)
 show_boards:
 		@$(CAT) $(BOARDS_TXT) | grep -E '^[a-zA-Z0-9_\-]+.name' | sort -uf | sed 's/.name=/:/' | column -s: -t
 
+show_submenu:
+	@$(CAT) $(BOARDS_TXT) | grep -E '[a-zA-Z0-9_\-]+.menu.cpu.[a-zA-Z0-9_\-]+=' | sort -uf | sed 's/.menu.cpu./:/' | sed 's/=/:/' | column -s: -t
+
 monitor:
 ifeq ($(MONITOR_CMD), 'putty')
 	ifneq ($(strip $(MONITOR_PARMS)),)
@@ -1543,6 +1546,7 @@ help:
   make reset             - reset the Arduino by tickling DTR or changing baud\n\
                            rate on the serial port.\n\
   make show_boards       - list all the boards defined in boards.txt\n\
+  make show_submenu      - list all board submenus defined in boards.txt\n\
   make monitor           - connect to the Arduino's serial port\n\
   make size              - show the size of the compiled output (relative to\n\
                            resources, if you have a patched avr-size).\n\

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 
 ### In Development
 
+- New: Add show_submenu target (https://github.com/drewhutchison)
 - New: Add AVR Dragon to list of ISP's without a port (https://github.com/mtnocean)
 - New: Add more board examples to Blink demo (https://github.com/sej7278)
 - New: Add option to split avrdude MCU from avr-gcc MCU (Issue #357) (https://github.com/hhgarnes)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -281,7 +281,7 @@ BOARD_TAG = uno or mega2560
 
 **Description:**
 
-1.5+ submenu as listed in `boards.txt`
+1.5+ submenu as listed in `boards.txt` or `make show_submenu`.
 
 **Example:**
 


### PR DESCRIPTION
Added a make target `show_submenu` to aid in setting `BOARD_SUB` analogously to using `show_boards` for `BOARD_TAG`.