### PR TITLE
Change CXXFLAGS_STD to match upstream

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -472,8 +472,12 @@ ifndef AVR_TOOLS_PATH
     AVR_TOOLS_PATH    = $(AVR_TOOLS_DIR)/bin
 endif
 
-ARDUINO_LIB_PATH  = $(ARDUINO_DIR)/libraries
-$(call show_config_variable,ARDUINO_LIB_PATH,[COMPUTED],(from ARDUINO_DIR))
+ifndef ARDUINO_LIB_PATH
+    ARDUINO_LIB_PATH = $(ARDUINO_DIR)/libraries
+    $(call show_config_variable,ARDUINO_LIB_PATH,[COMPUTED],(from ARDUINO_DIR))
+else
+    $(call show_config_variable,ARDUINO_LIB_PATH,[USER])
+endif
 
 # 1.5.x platform dependent libs path
 ifndef ARDUINO_PLATFORM_LIB_PATH
@@ -1035,7 +1039,11 @@ else
 endif
 
 ifndef CXXFLAGS_STD
-    CXXFLAGS_STD      =
+    ifeq ($(shell expr $(ARDUINO_VERSION) '>' 150), 1)
+        CXXFLAGS_STD      = -std=gnu++11 -fno-threadsafe-statics
+    else
+        CXXFLAGS_STD      =
+    endif
     $(call show_config_variable,CXXFLAGS_STD,[DEFAULT])
 else
     $(call show_config_variable,CXXFLAGS_STD,[USER])

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -929,7 +929,7 @@ CFLAGS_STD = = -std=gnu89
 
 Controls, *exclusively*, which C++ standard is to be used for compilation.
 
-Defaults to `undefined`
+Defaults to `undefined` on 1.0 or `-std=gnu++11 -fno-threadsafe-statics` on 1.5+
 
 Possible values:
 


### PR DESCRIPTION
Added ```-std=gnu++11 -fno-threadsafe-statics``` to ```CXXFLAGS_STD``` if we're using Arduino 1.6 to match upstream (without it compilation seems to fail on OSX). Updated docs. Fixes #424 

Also made ```ARDUINO_LIB_PATH``` overloadable although this is a pretty niche use-case, see #441

Probably need to update HISTORY.md with the last couple of commits too.