### PR TITLE
Changed LTO support check to avr-gcc > 4.9.0 

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1032,7 +1032,7 @@ CC_VERNUM = $(shell $(CC) -dumpversion | sed 's/\.//g')
 
 # moved from above so we can find version-dependant ar
 ifndef AR_NAME
-    ifeq ($(shell expr $(CC_VERNUM) '>' 480), 1)
+    ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
         AR_NAME      = avr-gcc-ar
     else
         AR_NAME      = avr-ar
@@ -1040,7 +1040,7 @@ ifndef AR_NAME
 endif
 
 ifndef CFLAGS_STD
-    ifeq ($(shell expr $(CC_VERNUM) '>' 480), 1)
+    ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
         CFLAGS_STD      = -std=gnu11 -flto -fno-fat-lto-objects
     else
         CFLAGS_STD        =
@@ -1051,7 +1051,7 @@ else
 endif
 
 ifndef CXXFLAGS_STD
-    ifeq ($(shell expr $(CC_VERNUM) '>' 480), 1)
+    ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
         CXXFLAGS_STD      = -std=gnu++11 -fno-threadsafe-statics -flto
     else
         CXXFLAGS_STD      =
@@ -1064,11 +1064,11 @@ endif
 CFLAGS        += $(CFLAGS_STD)
 CXXFLAGS      += -fpermissive -fno-exceptions $(CXXFLAGS_STD)
 ASFLAGS       += -x assembler-with-cpp
-ifeq ($(shell expr $(CC_VERNUM) '>' 480), 1)
+ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
     ASFLAGS += -flto
 endif
 LDFLAGS       += -$(MCU_FLAG_NAME)=$(MCU) -Wl,--gc-sections -O$(OPTIMIZATION_LEVEL)
-ifeq ($(shell expr $(CC_VERNUM) '>' 480), 1)
+ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
     LDFLAGS += -flto -fuse-linker-plugin
 endif
 SIZEFLAGS     ?= --mcu=$(MCU) -C

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In Development
-- New: Add LTO support for users with avr-gcc > 4.8 (issue #446) (https://github.com/sej7278)
+- New: Add LTO support for users with avr-gcc > 4.9 (issue #446 & #456) (https://github.com/sej7278)
 - Tweak: Updated Linux instructions and sync documentation from the old blog(), README.md and Arduino.mk (https://github.com/az-z)
 - Fix: Updated CXXFLAGS_STD to match upstream 1.6 (issue #424) (https://github.com/calvinli)
 - Fix: Added support for attiny core's use of chip instead of cpu in submenus (https://github.com/straccio)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -822,7 +822,7 @@ OBJDUMP_NAME = pic32-objdump
 
 Archive utility.
 
-Defaults to `avr-ar` unless you're using toolchain > 4.8.0 in which case we use avr-gcc-ar.
+Defaults to `avr-ar` unless you're using toolchain > 4.9.0 in which case we use avr-gcc-ar.
 
 **Example:**
 
@@ -894,7 +894,7 @@ OPTIMIZATION_LEVEL = 3
 
 Controls, *exclusively*, which C standard is to be used for compilation.
 
-Defaults to `undefined` on 1.0.x or `-std=gnu11 -flto -fno-fat-lto-objects` on 1.5+ or if you install AVR toolchain > 4.8.0
+Defaults to `undefined` on 1.0.x or `-std=gnu11 -flto -fno-fat-lto-objects` on 1.5+ or if you install AVR toolchain > 4.9.0
 
 Possible values:
 
@@ -929,7 +929,7 @@ CFLAGS_STD = = -std=gnu89
 
 Controls, *exclusively*, which C++ standard is to be used for compilation.
 
-Defaults to `undefined` on 1.0 or `-std=gnu++11 -fno-threadsafe-statics -flto` on AVR toolchain > 4.8.0 (e.g. IDE 1.5+)
+Defaults to `undefined` on 1.0 or `-std=gnu++11 -fno-threadsafe-statics -flto` on AVR toolchain > 4.9.0 (e.g. IDE 1.6.10+)
 
 Possible values:
 


### PR DESCRIPTION
The avr-gcc 4.8.1 bundled with the IDE prior to 1.6.10 doesn't support LTO or plugins. Fixes Issue #456 

So essentially LTO support will only be enabled with avr-gcc 4.9.2 which comes with 1.6.10 or later
and Debian, Ubuntu etc; not 4.8.1 which comes with IDE 1.6.9 and a few earlier versions.

Tested with:

 * 1.6.8 (avr-gcc 4.8.1 which doesn't support LTO so uses avr-ar and doesn't set LTO flags)
 * 1.6.12 (avr-gcc 4.9.2 which supports LTO so uses avr-gcc-ar and sets LTO flags)
 * 1.0.5 with Debian avr-gcc 4.9.2 (supports LTO so uses avr-gcc-ar and sets LTO flags)