### PR TITLE
Update to work with Arduino 1.6.12 and Teensyduino 1.30

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1293,7 +1293,7 @@ endif
 $(OBJDIR)/%.eep: $(OBJDIR)/%.elf $(COMMON_DEPS)
 	@$(MKDIR) $(dir $@)
 	-$(OBJCOPY) -j .eeprom --set-section-flags=.eeprom='alloc,load' \
-		--change-section-lma .eeprom=0 -O ihex $< $@
+		--no-change-warnings --change-section-lma .eeprom=0 -O ihex $< $@
 
 $(OBJDIR)/%.lss: $(OBJDIR)/%.elf $(COMMON_DEPS)
 	@$(MKDIR) $(dir $@)
@@ -1439,7 +1439,7 @@ pre-build:
 		$(call runscript_if_exists,$(PRE_BUILD_HOOK))
 
 $(TARGET_ELF): 	$(LOCAL_OBJS) $(CORE_LIB) $(OTHER_OBJS)
-		$(CC) $(LDFLAGS) -o $@ $(LOCAL_OBJS) $(CORE_LIB) $(OTHER_OBJS) -lc -lm $(LINKER_SCRIPTS)
+		$(CC) $(LDFLAGS) -o $@ $(LOCAL_OBJS) $(CORE_LIB) $(OTHER_OBJS) $(OTHER_LIBS) -lc -lm $(LINKER_SCRIPTS)
 
 $(CORE_LIB):	$(CORE_OBJS) $(LIB_OBJS) $(PLATFORM_LIB_OBJS) $(USER_LIB_OBJS)
 		$(AR) rcs $@ $(CORE_OBJS) $(LIB_OBJS) $(PLATFORM_LIB_OBJS) $(USER_LIB_OBJS)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: ARDUINO_VERSION can cope with the longer 1.6.10 version string (issue #444) (https://github.com/sej7278)
 - Fix: Changed PARSE_BOARD to handle colons in e.g. CORE or VARIANT (issue #461) (https://github.com/sej7278)
 - Tweak: Documentation for Windows updated to include installation of PySerial (https://github.com/sovcik) 
+- FIX: Changed Teensy.mk to support Arduino 1.6.12 and Teensyduino 1.30 (issues #383 , #431) (https://github.com/georgeharker)
 
 ### 1.5.1 (Debian version: 1.5-3) (2016-02-22)
 

--- a/Teensy.mk
+++ b/Teensy.mk
@@ -179,6 +179,10 @@ LDFLAGS += -Wl,--gc-sections,--relax
 LINKER_SCRIPTS = -T${ARDUINO_CORE_PATH}/${AMCU}.ld
 OTHER_LIBS = $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.libs)
 
+CPUFLAGS = $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.cpu)
+# usually defined as per teensy31.build.mcu=mk20dx256 but that isn't valid switch
+MCU := $(shell echo ${CPUFLAGS} | sed -n -e 's/.*-mcpu=\([a-zA-Z0-9_-]*\).*/\1/p')
+
 ########################################################################
 # some fairly odd settings so that 'make upload' works
 #

--- a/Teensy.mk
+++ b/Teensy.mk
@@ -49,6 +49,12 @@ endif
 ARCHITECTURE  = $(call PARSE_TEENSY,$(BOARD_TAG),build.architecture)
 AVR_TOOLS_DIR = $(call dir_if_exists,$(ARDUINO_DIR)/hardware/tools/$(ARCHITECTURE))
 
+# define plaform lib dir ignoring teensy's oversight on putting it all in avr
+ifndef ARDUINO_PLATFORM_LIB_PATH
+    ARDUINO_PLATFORM_LIB_PATH = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/avr/libraries
+    $(call show_config_variable,ARDUINO_PLATFORM_LIB_PATH,[COMPUTED],(from ARDUINO_DIR))
+endif
+
 ########################################################################
 # command names
 

--- a/Teensy.mk
+++ b/Teensy.mk
@@ -34,8 +34,8 @@ endif
 include $(ARDMK_DIR)/Common.mk
 
 ARDMK_VENDOR        = teensy
-ARDUINO_CORE_PATH   = $(ARDUINO_DIR)/hardware/teensy/cores/teensy3
-BOARDS_TXT          = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/boards.txt
+ARDUINO_CORE_PATH   = $(ARDUINO_DIR)/hardware/teensy/avr/cores/teensy3
+BOARDS_TXT          = $(ARDUINO_DIR)/hardware/$(ARDMK_VENDOR)/avr/boards.txt
 
 ifndef F_CPU
     F_CPU=96000000
@@ -152,11 +152,26 @@ ifeq ("$(call PARSE_TEENSY,$(BOARD_TAG),build.elide_constructors)", "true")
     CXXFLAGS      += -felide-constructors
 endif
 
-LDFLAGS +=  $(call PARSE_TEENSY,$(BOARD_TAG),build.linkoption) $(call PARSE_TEENSY,$(BOARD_TAG),build.additionalobject)
+CXXFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.common)
+CXXFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.cpu)
+CXXFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.defs)
+CXXFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.cpp)
 
-ifneq ("$(call PARSE_TEENSY,$(BOARD_TAG),build.linkscript)",)
-    LDFLAGS   += -T$(ARDUINO_CORE_PATH)/$(call PARSE_TEENSY,$(BOARD_TAG),build.linkscript)
-endif
+CFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.common)
+CFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.cpu)
+CFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.defs)
+
+ASFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.common)
+ASFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.cpu)
+ASFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.defs)
+ASFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.S)
+
+LDFLAGS += $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.cpu)
+
+AMCU := $(call PARSE_TEENSY,$(BOARD_TAG),build.mcu)
+LDFLAGS += -Wl,--gc-sections,--relax
+LINKER_SCRIPTS = -T${ARDUINO_CORE_PATH}/${AMCU}.ld
+OTHER_LIBS = $(call PARSE_TEENSY,$(BOARD_TAG),build.flags.libs)
 
 ########################################################################
 # some fairly odd settings so that 'make upload' works
@@ -171,3 +186,4 @@ RESET_CMD = nohup $(ARDUINO_DIR)/hardware/tools/teensy_post_compile -board=$(BOA
 # automatially include Arduino.mk for the user
 
 include $(ARDMK_DIR)/Arduino.mk
+

--- a/Teensy.mk
+++ b/Teensy.mk
@@ -48,7 +48,7 @@ endif
 
 # if boards.txt gets modified, look there, else hard code it
 ARCHITECTURE  = $(call PARSE_TEENSY,$(BOARD_TAG),build.architecture)
-ifeq ($(strip $(MONITOR_PORT)),)
+ifeq ($(strip $(ARCHITECTURE)),)
 	ARCHITECTURE = arm
 endif
 

--- a/Teensy.mk
+++ b/Teensy.mk
@@ -46,7 +46,12 @@ ifndef PARSE_TEENSY
     PARSE_TEENSY = $(shell grep -v "^\#" "$(BOARDS_TXT)" | grep $(1).$(2) | cut -d = -f 2,3 )
 endif
 
+# if boards.txt gets modified, look there, else hard code it
 ARCHITECTURE  = $(call PARSE_TEENSY,$(BOARD_TAG),build.architecture)
+ifeq ($(strip $(MONITOR_PORT)),)
+	ARCHITECTURE = arm
+endif
+
 AVR_TOOLS_DIR = $(call dir_if_exists,$(ARDUINO_DIR)/hardware/tools/$(ARCHITECTURE))
 
 # define plaform lib dir ignoring teensy's oversight on putting it all in avr

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -888,6 +888,24 @@ OPTIMIZATION_LEVEL = 3
 
 ----
 
+### OTHER_LIBS
+
+**Description:**
+
+Additional Linker lib flags, for platform support
+
+Defaults to ""
+
+**Example:**
+
+```Makefile
+OTHER_LIBS = -lsomeplatformlib
+```
+
+**Requirement:** *Optional*
+
+----
+
 ### CFLAGS_STD
 
 **Description:**


### PR DESCRIPTION
Lots of things got moved about at some point by teensyduino (in particular boards.txt got restructured).
It's actually missing a teensy31.build.architecture which needs to be set to arm (similarly for other boards)

But these changes (and that one line for boards.txt) allow the new options to be pulled from boards.txt and passed through.  Mostly it's just updating to get that to work.