### PR TITLE
Fix parsing of Teensy options with multiple "="s

### DIFF
--- a/Teensy.mk
+++ b/Teensy.mk
@@ -43,7 +43,7 @@ endif
 
 ifndef PARSE_TEENSY
     # result = $(call READ_BOARD_TXT, 'boardname', 'parameter')
-    PARSE_TEENSY = $(shell grep -v "^\#" "$(BOARDS_TXT)" | grep $(1).$(2) | cut -d = -f 2,3 )
+    PARSE_TEENSY = $(shell grep -v "^\#" "$(BOARDS_TXT)" | grep $(1).$(2) | cut -d = -f 2- )
 endif
 
 # if boards.txt gets modified, look there, else hard code it


### PR DESCRIPTION
The new Teensy 3.5/3.6 boards have arrived and boards.txt now has some configuration lines that have multiple "=" signs that aren't handled correctly by the current value of `PARSE_TEENSY`. Specifically, `teensy35.build.flags.cpu` get cuts off at the second "=" the the `-mfloat-abi` option has no value and the rest of the options are left out. Fortunately it's simple to fix by changing the field option of the cut command.