### PR TITLE
Fix generate_assembly for cpp files.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1262,7 +1262,7 @@ $(OBJDIR)/%.s: %.ino $(COMMON_DEPS) | $(OBJDIR)
 
 $(OBJDIR)/%.s: %.cpp $(COMMON_DEPS) | $(OBJDIR)
 	@$(MKDIR) $(dir $@)
-	$(CXX) -x c++ -include $(ARDUINO_HEADER) -MMD -S -fverbose-asm $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+	$(CXX) -x c++ -MMD -S -fverbose-asm $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 # core files
 $(OBJDIR)/core/%.c.o: $(ARDUINO_CORE_PATH)/%.c $(COMMON_DEPS) | $(OBJDIR)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ A Makefile for Arduino Sketches
 The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
+### In Development
+
 ### 1.5.2 (2017-01-11)
 
 - New: Add LTO support for users with avr-gcc > 4.9 (issue #446 & #456) (https://github.com/sej7278)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In Development
+- Fix: Do not include the Arduino header when calling generate_assembly on .cpp files. (https://github.com/Batchyx)
 
 ### 1.5.2 (2017-01-11)
 


### PR DESCRIPTION
Do not include the Arduino header when generating assembly for .cpp
files with generate_assembly.  This was likely a copy-paste error.

Also included is a commit to re-create a "In Development" section in HISTORY.md