### PR TITLE
Fixes for Fedora: optional LTO, ccache compatibility

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -902,6 +902,9 @@ ifndef OVERRIDE_EXECUTABLES
     AR      = $(AVR_TOOLS_PATH)/$(AR_NAME)
     SIZE    = $(AVR_TOOLS_PATH)/$(SIZE_NAME)
     NM      = $(AVR_TOOLS_PATH)/$(NM_NAME)
+
+    # Check if the default exist, otherwise try to find in PATH
+    $(foreach C,CC CXX AS OBJCOPY OBJDUMP AR SIZE NM,$(if $(wildcard $C),,$(eval $C = $$(shell type -p $$($(C)_NAME)))))
 endif
 
 REMOVE  = rm -rf

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1046,7 +1046,12 @@ ifndef AR_NAME
 endif
 
 ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
-    USE_LTO ?= 1
+    DISTRO=$(if $(wildcard /etc/os-release),$(shell sed -n "/^ID=/ s/ID=//p" /etc/os-release),unknown)
+    ifeq ($(DISTRO),fedora)
+        USE_LTO ?= 0
+    else
+        USE_LTO ?= 1
+    endif
 endif
 
 

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1039,9 +1039,17 @@ ifndef AR_NAME
     endif
 endif
 
+ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
+    USE_LTO ?= 1
+endif
+
+
 ifndef CFLAGS_STD
     ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
-        CFLAGS_STD      = -std=gnu11 -flto -fno-fat-lto-objects
+        CFLAGS_STD      = -std=gnu11
+        ifeq ($(USE_LTO),1)
+            CFLAGS_STD += -flto -fno-fat-lto-objects
+        endif
     else
         CFLAGS_STD        =
     endif
@@ -1052,7 +1060,10 @@ endif
 
 ifndef CXXFLAGS_STD
     ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
-        CXXFLAGS_STD      = -std=gnu++11 -fno-threadsafe-statics -flto
+        CXXFLAGS_STD      = -std=gnu++11 -fno-threadsafe-statics
+        ifeq ($(USE_LTO),1)
+            CXXFLAGS_STD += -flto
+        endif
     else
         CXXFLAGS_STD      =
     endif
@@ -1064,11 +1075,11 @@ endif
 CFLAGS        += $(CFLAGS_STD)
 CXXFLAGS      += -fpermissive -fno-exceptions $(CXXFLAGS_STD)
 ASFLAGS       += -x assembler-with-cpp
-ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
+ifeq ($(USE_LTO), 1)
     ASFLAGS += -flto
 endif
 LDFLAGS       += -$(MCU_FLAG_NAME)=$(MCU) -Wl,--gc-sections -O$(OPTIMIZATION_LEVEL)
-ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
+ifeq ($(USE_LTO), 1)
     LDFLAGS += -flto -fuse-linker-plugin
 endif
 SIZEFLAGS     ?= --mcu=$(MCU) -C

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -444,6 +444,9 @@ ifndef AVR_TOOLS_DIR
         ifdef SYSTEMPATH_AVR_TOOLS_DIR
             AVR_TOOLS_DIR = $(SYSTEMPATH_AVR_TOOLS_DIR)
             $(call show_config_variable,AVR_TOOLS_DIR,[AUTODETECTED],(found in $$PATH))
+            ifndef AVRDUDE_CONF
+                AVRDUDED_CONF := $(call dir_if_exists,/etc/avrdude/avrdude.conf)
+            endif
         else
             echo $(error No AVR tools directory found)
         endif # SYSTEMPATH_AVR_TOOLS_DIR

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Do not include the Arduino header when calling generate_assembly on .cpp files. (https://github.com/Batchyx)
 - Fix: Auto-detect F_CPU on Teensy from boards.txt (https://github.com/DaWelter)
 - Tweak: Allow to disable LTO (currently crashes on Fedora 25)
+- Fix: find AVRDUDE_CONF for system avrdude
 
 ### 1.5.2 (2017-01-11)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Auto-detect F_CPU on Teensy from boards.txt (https://github.com/DaWelter)
 - Tweak: Allow to disable LTO (currently crashes on Fedora 25)
 - Fix: find AVRDUDE_CONF for system avrdude
+- Fix: properly detect tool paths
 
 ### 1.5.2 (2017-01-11)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 ### In Development
 - Fix: Do not include the Arduino header when calling generate_assembly on .cpp files. (https://github.com/Batchyx)
 - Fix: Auto-detect F_CPU on Teensy from boards.txt (https://github.com/DaWelter)
+- Tweak: Allow to disable LTO (currently crashes on Fedora 25)
 
 ### 1.5.2 (2017-01-11)
 


### PR DESCRIPTION
Currently, Arduino.mk cannot easily be used on Fedora 25.
- There is a bug that makes avr-gcc crash with LTO enabled and using the Serial library (no further investigation as into why, it's just that at this time it is broken)
- When enabling ccache one currently has to override the executables explicitly as the base assumption is that everything is combined in one single avr tools directory

This pull request overcomes these issues by:
- make LTO optimization optional through the USE_LTO variable to override its use
- disable LTO by default if Fedora is detected (all other systems operate as before)
- verify tool paths and if the paths do not resolve (i.e., there is no avr tools dir but the tools are in the system path) try to find it in the PATH
- for a system path avrdude, try to guess the config file to be in the system config directory, too (did not set any before)

As far as I can tell the changes are backward compatible. The LTO fix is crucial, the path fix is for convenience and to have to override executables less often.