### PR TITLE
show_submenu: fix sed expression

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1522,7 +1522,7 @@ show_boards:
 		@$(CAT) $(BOARDS_TXT) | grep -E '^[a-zA-Z0-9_\-]+.name' | sort -uf | sed 's/.name=/:/' | column -s: -t
 
 show_submenu:
-	@$(CAT) $(BOARDS_TXT) | grep -E '[a-zA-Z0-9_\-]+.menu.(cpu|chip).[a-zA-Z0-9_\-]+=' | sort -uf | sed 's/.menu.(cpu|chip)./:/' | sed 's/=/:/' | column -s: -t
+	@$(CAT) $(BOARDS_TXT) | grep -E '[a-zA-Z0-9_\-]+.menu.(cpu|chip).[a-zA-Z0-9_\-]+=' | sort -uf | sed 's/.menu.\(cpu\|chip\)./:/' | sed 's/=/:/' | column -s: -t
 
 monitor:
 ifeq ($(MONITOR_CMD), 'putty')


### PR DESCRIPTION
The matching parentheses and | in sed expresssions need to be escaped
or sed will consider like normal characters.

Without this fix, make show_submenu was showing lines like this one:

  pro.menu.cpu.8MHzatmega328    ATmega328 (3.3V, 8 MHz)

It now properly outputs lines like this:

  pro        8MHzatmega328   ATmega328 (3.3V, 8 MHz)

This output is much less misleading to users especially newcomers.