### PR TITLE
Add support for cu as MONITOR_CMD

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1533,6 +1533,8 @@ ifeq ($(MONITOR_CMD), 'putty')
 	endif
 else ifeq ($(MONITOR_CMD), picocom)
 		$(MONITOR_CMD) -b $(MONITOR_BAUDRATE) $(MONITOR_PARAMS) $(call get_monitor_port)
+else ifeq ($(MONITOR_CMD), cu)
+		$(MONITOR_CMD) -l $(call get_monitor_port) -s $(MONITOR_BAUDRATE)
 else
 		$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)
 endif

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Auto-detect F_CPU on Teensy from boards.txt (https://github.com/DaWelter)
 - Fix: params typo in PuTTY section (issue #487) (https://github.com/ericdand)
 - Fix: Fixed sed expression to properly format show_submenu (issue #488) (https://github.com/cbosdo)
+- New: Add support for good old cu as monitor command (issue #492) (https://github.com/mwm)
 
 ### 1.5.2 (2017-01-11)
 


### PR DESCRIPTION
Use ~. to exit, be mindful when using over ssh as it can mess with the escape character

Pretty oldskool, but if you must.....

Thanks @mwm, issue #492 