### PR TITLE
Support for generation of project tags file

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1320,7 +1320,7 @@ ifndef TAGS_FILE
     TAGS_FILE = tags
 endif
 
-# ctags command: append file with user options before
+# ctags command: append, flags unsort (as will be sorted after) and specify filename
 CTAGS_CMD = $(CTAGS_EXEC) $(CTAGS_OPTS) -auf
 
 ########################################################################
@@ -1580,7 +1580,9 @@ generated_assembly: generate_assembly
 
 .PHONY: tags
 tags:
-	rm -f $(shell pwd)/$(TAGS_FILE)
+ifneq ($(words $(wildcard $(TAGS_FILE))), 0)
+	rm -f $(TAGS_FILE)
+endif
 	@$(ECHO) "Generating tags for local sources (INO an PDE files as C++): "
 	$(CTAGS_CMD) $(TAGS_FILE) --langmap=c++:.ino --langmap=c++:.pde $(LOCAL_SRCS)
 ifneq ($(words $(ARDUINO_LIBS)), 0)

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1581,7 +1581,7 @@ generated_assembly: generate_assembly
 .PHONY: tags
 tags:
 	rm -f $(shell pwd)/$(TAGS_FILE)
-	@$(ECHO) "Generating tags for local sources (IDO an PDE files as C++): "
+	@$(ECHO) "Generating tags for local sources (INO an PDE files as C++): "
 	$(CTAGS_CMD) $(TAGS_FILE) --langmap=c++:.ino --langmap=c++:.pde $(LOCAL_SRCS)
 ifneq ($(words $(ARDUINO_LIBS)), 0)
 		@$(ECHO) "Generating tags for project libraries: "

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1581,17 +1581,17 @@ generated_assembly: generate_assembly
 .PHONY: tags
 tags:
 	rm -f $(shell pwd)/$(TAGS_FILE)
-	@$(ECHO) "Generating tags for source files: "
-	$(CTAGS_CMD) $(TAGS_FILE) $(shell find "`pwd`" -name "*.cpp" -o -name "*.h" -o -name "*.c") 
-	@$(ECHO) "Generating tags for IDO an PDE files as C++: "
-	$(CTAGS_CMD) $(TAGS_FILE) --langmap=c++:.ino --langmap=c++:.pde $(shell find "`pwd`" -name "*.ino" -o -name "*.pde")
-	@$(ECHO) "Generating tags for project libraries: "
-	$(CTAGS_CMD) $(TAGS_FILE) $(foreach lib, $(ARDUINO_LIBS),$(USER_LIB_PATH)/$(lib)/*)
+	@$(ECHO) "Generating tags for local sources (IDO an PDE files as C++): "
+	$(CTAGS_CMD) $(TAGS_FILE) --langmap=c++:.ino --langmap=c++:.pde $(LOCAL_SRCS)
+ifneq ($(words $(ARDUINO_LIBS)), 0)
+		@$(ECHO) "Generating tags for project libraries: "
+		$(CTAGS_CMD) $(TAGS_FILE) $(foreach lib, $(ARDUINO_LIBS),$(USER_LIB_PATH)/$(lib)/*)
+endif
 	@$(ECHO) "Generating tags for Arduino core: "
 	$(CTAGS_CMD) $(TAGS_FILE) $(ARDUINO_CORE_PATH)/*
 	@$(ECHO) "Sorting..\n"
 	@sort $(TAGS_FILE) -o $(TAGS_FILE)
-	@$(ECHO) "Tag file generation complete, output: $(TAGS_FILE)"
+	@$(ECHO) "Tag file generation complete, output: $(TAGS_FILE)\n"
 
 help_vars:
 		@$(CAT) $(ARDMK_DIR)/arduino-mk-vars.md

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Add support for good old cu as monitor command (issue #492) (https://github.com/mwm)
 - Tweak: Removed tilde from documentation (issue #497). (https://github.com/sej7278)
 - New: Add a documentation how to setup Makefile for 3rd party boards (issue #499). (https://github.com/MilanV)
+- New: Add generation of tags file using ctags, which automatically includes project libs and Arduino core. (https://github.com/tuna-f1sh)
 
 ### 1.5.2 (2017-01-11)
 

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -11,6 +11,7 @@ The following are the different variables that can be overwritten in the user ma
 *	[Avrdude setting variables](#avrdude-setting-variables)
 *	[Bootloader variables](#bootloader-variables)
 *	[ChipKIT variables](#chipkit-variables)
+*	[Ctags variables](#ctags-variables)
 
 ## Global variables
 
@@ -1396,6 +1397,57 @@ Usually can be auto-detected as `AUTO_MPIDE_DIR` from the defaults `/usr/share/m
 
 ```Makefile
 MPIDE_DIR = $(HOME)/mpide
+```
+
+**Requirement:** *Optional*
+
+----
+
+## Ctags variables
+
+### TAGS_FILE
+
+**Description:**
+
+Output file name for tags. Defaults to 'tags'.
+
+**Example:**
+
+```Makefile
+TAGS_FILE = .tags
+```
+
+**Requirement:** *Optional*
+
+----
+
+### CTAGS_OPTS
+
+**Description:**
+
+Additional options to pass to `ctags` command.
+
+**Example:**
+
+```Makefile
+# Run ctags in verbose mode
+CTAGS_OPTS = -V
+```
+
+**Requirement:** *Optional*
+
+----
+
+### CTAGS_CMD
+
+**Description:**
+
+Location of `ctags` binary. Defaults to user path.
+
+**Example:**
+
+```Makefile
+CTAGS_CMD = /usr/local/bin/
 ```
 
 **Requirement:** *Optional*


### PR DESCRIPTION
Considering the number of project files spread in different locations when developing an Arduino project, proper use of tags can be difficult; resolving beyond local functions.

I've added automatic generation of a tags file, which includes:

* Standard source in project dir (.c, .cpp, .h)
* Arduino source in project dir (.ide, .pde)
* Arduino core based on detected project core from Arduino install.
* Included Arduino libraries from user library folder.

As a Vim user I find this hugely useful and think it would be a useful addition for others. Target has been added as `make tags`. There may be some better practices, for some things (I'm not sure about using `pwd` in the shells commands?). I've included a few variables, see updates variables file.

John.