### PR TITLE
Added ARDUINO_SKETCHBOOK to include list to improve search for items in ARDUINO_LIBS

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1014,7 +1014,7 @@ endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
 CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) $(ARDUINO_ARCH_FLAG) -D__PROG_TYPES_COMPAT__ \
-        -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
+        -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_SKETCHBOOK) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections
 


### PR DESCRIPTION
This fixes the problems discussed in issue #497.

In short, there's currently no reliable way to compile code with Arduino-Makefile that uses an include like:

    #include "Adafruit_BNO055/Adafruit_Sensor.h"

If the library `Adafruit_BNO055` is located `USER_LIB_PATH`, then Arduino-Makefile auto-generates the include `-I$(USER_LIB_PATH)/Adafruit_BNO055`, which allows you to make includes like:

    #include "Adafruit_Sensor.h"

but this could lead to conflicts when other libraries use the same filename.

You can get it to compile for a single library by setting `USER_LIB_PATH = /full/path/to/Adafruit_BNO055/..` but since `USER_LIB_PATH` is used as the base for constructing all other include search paths, it'll cause an error for all other libraries in your `ARDUINO_LIBS`.

The other advantage of this modification is that it makes custom `.lib/` directories trivially easy to implement by simply settings this value in your `ARDUINO_SKETCHBOOK`. Using a custom sketchbook directory per project allows better encapsulation and prevents maintenance headaches and version conflicts. Howeever, by not using the sketchbook directory as an include path itself, you greatly limit its usefulness.

Before using Arduino-Makefile, I used the now defunct [Inotool](https://github.com/amperka/ino), which assumes this relative path in your project by default. The lack of this feature in Arduino-Makefile is the only thing stopping me from adopting it for all my Arduino projects.