### PR TITLE
Add -fno-devirtualize to CXXFLAGS_STD

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1045,7 +1045,7 @@ endif
 
 ifndef CFLAGS_STD
     ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
-        CFLAGS_STD      = -std=gnu11 -flto -fno-fat-lto-objects
+        CFLAGS_STD      = -std=gnu11 -flto -fno-fat-lto-objects -fdiagnostics-color
     else
         CFLAGS_STD        =
     endif
@@ -1056,7 +1056,7 @@ endif
 
 ifndef CXXFLAGS_STD
     ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
-        CXXFLAGS_STD      = -std=gnu++11 -fno-threadsafe-statics -flto
+        CXXFLAGS_STD      = -std=gnu++11 -fno-threadsafe-statics -flto -fno-devirtualize -fdiagnostics-color
     else
         CXXFLAGS_STD      =
     endif
@@ -1164,7 +1164,7 @@ endif
 
 ########################################################################
 # Tools version info
-ARDMK_VERSION = 1.5
+ARDMK_VERSION = 1.6
 $(call show_config_variable,ARDMK_VERSION,[COMPUTED])
 
 CC_VERSION := $(shell $(CC) -dumpversion)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,9 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In Development
-- TBC
+- Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)
+- Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
+- New: Added -fdiagnostics-color to *STD flags (https://github.com/sej7278)
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)


### PR DESCRIPTION
Workaround for a g++ bug. As this could impact performance we should track when the issue is fixed upstream to remove the flag again (see links from Issue #486)

Enabled colourised diagnostics from avr-gcc

We forgot to increase ARDMK_VERSION for the 1.6.0 release