### PR TITLE
Quote the prefix tag in the space_pad_to function

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -14,7 +14,7 @@ runscript_if_exists =                                                          \
 
 # For message printing: pad the right side of the first argument with spaces to
 # the number of bytes indicated by the second argument.
-space_pad_to = $(shell echo $(1) "                                                      " | head -c$(2))
+space_pad_to = $(shell echo "$(1)                                                       " | head -c$(2))
 
 # Call with some text, and a prefix tag if desired (like [AUTODETECTED]),
 show_config_info = $(call arduino_output,- $(call space_pad_to,$(2),20) $(1))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 
 ### In Development
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)
+- Fix: Quote the prefix tag in the space_pad_to function
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - New: Added -fdiagnostics-color to *STD flags (https://github.com/sej7278)
 


### PR DESCRIPTION
POSIX shells treat an unquoted [abcd] as a pattern bracket expression
and apply it for filename expansion.  This kicks in and causes
troubles in the space_pad_to function when it's called to pad prefix
tags like '[AUTODETECT]', because the argument holding such a tag is
passed to a shell unquoted.  The result is funny output when the
directory containing the Makefile also contains any files or
directories, whose name is a single upper-case character that can be
found in any prefix tags:

```
  $ touch A B C D
  $ make
  -------------------------
  Arduino.mk Configuration:
  - A C D                CURRENT_OS = LINUX
  - [USER]               ARDUINO_DIR = /home/szeder/src/arduino/arduino-1.8.1
  - [USER]               ARDMK_DIR = /home/szeder/src/arduino/Arduino-Makefile
  - A C D                ARDUINO_VERSION = 181
  - A D                  ARCHITECTURE = avr
  - A D                  ARDMK_VENDOR = arduino
  - A D                  ARDUINO_SKETCHBOOK =
  <snip>
```

Prevent this by quoting space_pad_to's parameter when passing it to a
shell.