### PR TITLE
Search for headers and sources in all libraries' subfolders

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -924,16 +924,17 @@ rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst 
 # and library.properties file
 
 # Gets include flags for library
-get_library_includes = $(if $(and $(wildcard $(1)/src), $(wildcard $(1)/library.properties)), \
+get_library_includes = $(sort $(if $(and $(wildcard $(1)/src), $(wildcard $(1)/library.properties)), \
                            -I$(1)/src, \
-                           $(addprefix -I,$(1) $(wildcard $(1)/utility)))
+                           $(addprefix -I,$(1) $(wildcard $(1)/utility)) \
+                           $(addprefix -I,$(1) $(dir $(wildcard $(1)/*/)))))
 
 # Gets all sources with given extension (param2) for library (path = param1)
 # for old (1.0.x) layout looks in . and "utility" directories
 # for new (1.5.x) layout looks in src and recursively its subdirectories
-get_library_files  = $(if $(and $(wildcard $(1)/src), $(wildcard $(1)/library.properties)), \
+get_library_files  = $(sort $(if $(and $(wildcard $(1)/src), $(wildcard $(1)/library.properties)), \
                         $(call rwildcard,$(1)/src/,*.$(2)), \
-                        $(wildcard $(1)/*.$(2) $(1)/utility/*.$(2)))
+                        $(wildcard $(1)/*.$(2) $(1)/utility/*.$(2) $(1)/*/*.$(2))))
 
 # General arguments
 USER_LIBS      := $(sort $(wildcard $(patsubst %,$(USER_LIB_PATH)/%,$(ARDUINO_LIBS))))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In Development
+- Tweak: recursively look for .h and .c/.cpp files in library subfolders (issue #521). (https://github.com/ladislas)
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)
 - Fix: Quote the prefix tag in the space_pad_to function
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)


### PR DESCRIPTION
fixes #521 

I've kept the `utility` folder to make it clearer but I can remove it if you want.

let me know.