### PR TITLE
Update Windows documentation to allow non-relative paths

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -744,13 +744,23 @@ ifndef RESET_CMD
 	endif
     ifneq ($(CATERINA),)
         ifneq (,$(findstring CYGWIN,$(shell uname -s)))
+          # confirm user is using default cygwin unix Python (which uses ttySx) and not Windows Python (which uses COMx)
+          ifeq ($(shell which python),/usr/bin/python)
             RESET_CMD = $(ARD_RESET_ARDUINO) --caterina $(ARD_RESET_OPTS) $(DEVICE_PATH)
+          else
+            RESET_CMD = $(ARD_RESET_ARDUINO) --caterina $(ARD_RESET_OPTS) $(call get_monitor_port)
+          endif
         else
             RESET_CMD = $(ARD_RESET_ARDUINO) --caterina $(ARD_RESET_OPTS) $(call get_monitor_port)
         endif
     else
         ifneq (,$(findstring CYGWIN,$(shell uname -s)))
+          # confirm user is using default cygwin unix Python (which uses ttySx) and not Windows Python (which uses COMx)
+          ifeq ($(shell which python),/usr/bin/python)
             RESET_CMD = $(ARD_RESET_ARDUINO) $(ARD_RESET_OPTS) $(DEVICE_PATH)
+          else
+            RESET_CMD = $(ARD_RESET_ARDUINO) $(ARD_RESET_OPTS) $(call get_monitor_port)
+          endif
         else
             RESET_CMD = $(ARD_RESET_ARDUINO) $(ARD_RESET_OPTS) $(call get_monitor_port)
         endif

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -65,12 +65,12 @@
 # configuration options. Control Panel > System > Advanced system settings
 # Also take into account that when you set them you have to add '\' on
 # all spaces and special characters.
-# ARDUINO_DIR and AVR_TOOLS_DIR have to be relative and not absolute.
 # This are just examples, you have to adapt this variables accordingly to
-# your system.
+# your system. Note the difference between ARDMK_DIR, which can use /cygdrive/
+# and USER_LIB_PATH, which cannnot due to invoking with the build tools
 #
-#   ARDUINO_DIR   =../../../../../Arduino
-#   AVR_TOOLS_DIR =../../../../../Arduino/hardware/tools/avr
+#   ARDUINO_DIR   = C:/Arduino
+#   AVR_TOOLS_DIR = C:/Arduino/hardware/tools/avr
 #   ARDMK_DIR     = /cygdrive/c/Users/"YourUser"/Arduino-Makefile
 #
 # On Windows it is highly recommended that you create a symbolic link directory

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -62,12 +62,15 @@
 #   AVR_TOOLS_DIR = /usr
 #
 # On Windows declare this environmental variables using the windows
-# configuration options. Control Panel > System > Advanced system settings
-# Also take into account that when you set them you have to add '\' on
-# all spaces and special characters.
+# configuration options or Cygwin .bashrc. Control Panel > System > Advanced system settings
+# The paths must use Unix style forward slash and not have any spaces 
+# or escape charactors. One must use a symbolic link if the path does
+# contain spaces.
+#
 # This are just examples, you have to adapt this variables accordingly to
 # your system. Note the difference between ARDMK_DIR, which can use /cygdrive/
-# and USER_LIB_PATH, which cannnot due to invoking with the build tools
+# and USER_LIB_PATH, which cannnot due to invoking with the build tools.
+# It is best practice to avoid cygdrive all together.
 #
 #   ARDUINO_DIR   = C:/Arduino
 #   AVR_TOOLS_DIR = C:/Arduino/hardware/tools/avr
@@ -75,7 +78,7 @@
 #
 # On Windows it is highly recommended that you create a symbolic link directory
 # for avoiding using the normal directories name of windows such as
-# c:\Program Files (x86)\Arduino
+# C:\Program Files (x86)\Arduino
 # For this use the command mklink on the console.
 #
 #
@@ -364,9 +367,15 @@ ifndef ARDUINO_SKETCHBOOK
     ifneq ($(ARDUINO_SKETCHBOOK),)
         $(call show_config_variable,ARDUINO_SKETCHBOOK,[AUTODETECTED],(from arduino preferences file))
     else
-        ARDUINO_SKETCHBOOK := $(firstword \
-            $(call dir_if_exists,$(HOME)/sketchbook) \
-            $(call dir_if_exists,$(HOME)/Documents/Arduino) )
+				ifeq ($(CURRENT_OS), WINDOWS)
+						ARDUINO_SKETCHBOOK := $(firstword \
+								$(call dir_if_exists,$(USERPROFILE)/sketchbook) \
+								$(call dir_if_exists,$(USERPROFILE)/Documents/Arduino) )
+				else
+						ARDUINO_SKETCHBOOK := $(firstword \
+								$(call dir_if_exists,$(HOME)/sketchbook) \
+								$(call dir_if_exists,$(HOME)/Documents/Arduino) )
+				endif
         $(call show_config_variable,ARDUINO_SKETCHBOOK,[DEFAULT])
     endif
 else

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -367,15 +367,15 @@ ifndef ARDUINO_SKETCHBOOK
     ifneq ($(ARDUINO_SKETCHBOOK),)
         $(call show_config_variable,ARDUINO_SKETCHBOOK,[AUTODETECTED],(from arduino preferences file))
     else
-				ifeq ($(CURRENT_OS), WINDOWS)
-						ARDUINO_SKETCHBOOK := $(firstword \
-								$(call dir_if_exists,$(USERPROFILE)/sketchbook) \
-								$(call dir_if_exists,$(USERPROFILE)/Documents/Arduino) )
-				else
-						ARDUINO_SKETCHBOOK := $(firstword \
-								$(call dir_if_exists,$(HOME)/sketchbook) \
-								$(call dir_if_exists,$(HOME)/Documents/Arduino) )
-				endif
+        ifeq ($(CURRENT_OS), WINDOWS)
+            ARDUINO_SKETCHBOOK := $(firstword \
+            $(call dir_if_exists,$(USERPROFILE)/sketchbook) \
+            $(call dir_if_exists,$(USERPROFILE)/Documents/Arduino) )
+        else
+            ARDUINO_SKETCHBOOK := $(firstword \
+              $(call dir_if_exists,$(HOME)/sketchbook) \
+              $(call dir_if_exists,$(HOME)/Documents/Arduino) )
+        endif
         $(call show_config_variable,ARDUINO_SKETCHBOOK,[DEFAULT])
     endif
 else

--- a/Common.mk
+++ b/Common.mk
@@ -79,9 +79,3 @@ ifndef ARDUINO_DIR
 else
     $(call show_config_variable,ARDUINO_DIR,[USER])
 endif
-
-ifeq ($(CURRENT_OS),WINDOWS)
-    ifneq ($(shell echo $(ARDUINO_DIR) | egrep '^(/|[a-zA-Z]:\\)'),)
-        echo $(error On Windows, ARDUINO_DIR must be a relative path)
-    endif
-endif

--- a/Common.mk
+++ b/Common.mk
@@ -79,3 +79,9 @@ ifndef ARDUINO_DIR
 else
     $(call show_config_variable,ARDUINO_DIR,[USER])
 endif
+
+ifeq ($(CURRENT_OS),WINDOWS)
+		ifneq ($(shell echo $(ARDUINO_DIR) | egrep '\\|[[:space:]]|cygdrive'),)
+        echo $(error On Windows, ARDUINO_DIR and other defines must use forward slash and not contain spaces, special characters or be cygdrive relative)
+    endif
+endif

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,8 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Quote the prefix tag in the space_pad_to function
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - Tweak: Move non-standard-related items from CxxFLAGS_STD to CxxFLAGS (issue #523) (https://github.com/sej7278)
+- Tweak: Update Windows usage documentation and allow non-relative paths (issue #519) (https://github.com/tuna-f1sh)
+- Tweak: Support Cygwin Unix Python and Windows installation on Windows to pass correct port binding. (https://github.com/tuna-f1sh)
 - New: Added -fdiagnostics-color to *STD flags (https://github.com/sej7278)
 - New: Add generation of tags file using ctags, which automatically includes project libs and Arduino core. (https://github.com/tuna-f1sh)
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ You need to install Cygwin and its packages for Make, Perl and the following Ser
 Assuming you included Python in your Cygwin installation:
 
 1. download PySerial source package from [https://pypi.python.org/pypi/pyserial](https://pypi.python.org/pypi/pyserial)
-2. extract downloaded package running
-```tar xvzf dowloaded_package_name.tar.gz```
+2. extract downloaded package running `tar xvzf dowloaded_package_name.tar.gz`
 3. navigate to extracted package folder
 4. build and install Python module: 
  
@@ -137,6 +136,16 @@ python setup.py build
 python setup.py install
 ```
 
+Alternatively, if you have setup Cygwin to use a Windows Python installation,
+simply install using pip:
+
+```
+pip install pyserial
+```
+
+Arduino-Makefile should automatically detect the Python installation type and
+use the correct device port binding.
+
 ## Usage
 
 Download a copy of this repo somewhere to your system or install it through a package by following the above installation instruction.
@@ -144,7 +153,7 @@ Download a copy of this repo somewhere to your system or install it through a pa
 Sample makefiles are provided in the `examples/` directory.  E.g. [Makefile-example](examples/MakefileExample/Makefile-example.mk) demonstrates some of the more advanced options,
 whilst [Blink](examples/Blink/Makefile) demonstrates the minimal settings required for various boards like the Uno, Nano, Mega, Teensy, ATtiny etc.
 
-MAC:
+### Mac
 
 On the Mac with IDE 1.0 you might want to set:
 
@@ -158,24 +167,28 @@ On the Mac with IDE 1.0 you might want to set:
 
 On the Mac with IDE 1.5+ it's like above but with
 
-```
+```make
     ARDUINO_DIR   = /Applications/Arduino.app/Contents/Java
 ```
-LINUX:
+### Linux
 
 You can either declare following variables in your project's makefile or set them as environmental variables.
 
+```make
     ARDUINO_DIR – Directory where Arduino is installed
     ARDMK_DIR – Directory where you have copied the makefile
     AVR_TOOLS_DIR – Directory where avr tools are installed
+```
 
 Keep in mind, that Arduino 1.5.x+ comes with it's own copy of avr tools which you can leverage in your build process here.
 
 Example of  ~/.bashrc file:
 
-	export ARDUINO_DIR=/home/sudar/apps/arduino-1.0.5
-	export ARDMK_DIR=/home/sudar/Dropbox/code/Arduino-Makefile
-	export AVR_TOOLS_DIR=/usr/include
+```make
+    export ARDUINO_DIR=/home/sudar/apps/arduino-1.0.5
+    export ARDMK_DIR=/home/sudar/Dropbox/code/Arduino-Makefile
+    export AVR_TOOLS_DIR=/usr/include
+```
 
 Example of the project's make file:
 
@@ -184,16 +197,24 @@ Example of the project's make file:
     MONITOR_PORT  = /dev/ttyACM0
 ```
 
-WINDOWS:
+### Windows
 
-On Windows (using cygwin), you might want to set:
+On Windows (using Cygwin), you might want to set:
 
 ```make
-    ARDUINO_DIR   = ../../arduino
+    # Symbolic link to Arduino installation directory - see below
+    ARDUINO_DIR   = C:/Arduino
     ARDMK_DIR     = path/to/mkfile
+    ARDUINO_SKETCHBOOK = C:/Users/USERNAME/Documents/Arduino
     MONITOR_PORT  = com3
     BOARD_TAG     = mega2560
 ```
+
+**NOTE: Use forward slash not backslash and there should be no spaces or
+special characters in the Windows paths (due to Win/Unix crossover). The paths
+should not be *cygdrive* paths.** `ARDUINO_SKETCHBOOK` is defined to avoid
+automatic resolution, which resolve to *cygdrive* and is incompatable with the
+build tools.
 
 On Windows (using MSYS and PuTTY), you might want to set the following extra parameters:
 
@@ -205,44 +226,52 @@ On Windows (using MSYS and PuTTY), you might want to set the following extra par
 On Arduino 1.5+ installs, you should set the architecture to either `avr` or `sam` and if using a submenu CPU type, then also set that:
 
 ```make
-	ARCHITECTURE  = avr
+    ARCHITECTURE  = avr
     BOARD_TAG     = atmegang
     BOARD_SUB     = atmega168
 ```
 
-It is recommended in Windows that you create a symbolic link to avoid problems with file naming conventions on Windows. For example, if your your Arduino directory is in:
+#### Symbolic Link
 
-    c:\Program Files (x86)\Arduino
+It is recommended in Windows that you create a symbolic link to avoid problems with file naming conventions on Windows; unless one installs to a non-default location. For example, if your your Arduino directory is in:
+
+    C:\Program Files (x86)\Arduino
 
 You will get problems with the special characters on the directory name. More details about this can be found in [issue #94](https://github.com/sudar/Arduino-Makefile/issues/94)
 
 To create a symbolic link, you can use the command “mklink” on Windows, e.g.
 
 ```sh
-    mklink /d c:\Arduino c:\Program Files (x86)\Arduino
+mklink /d C:\Arduino C:\Program Files (x86)\Arduino
+```
+Alternatively if you've setup Cygwin hard symbolic links ([CYGWIN=winsymlinks:native](https://www.cygwin.com/cygwin-ug-net/using-cygwinenv.html)):
+
+```sh
+ln -s /cygdrive/c/Program Files\ \(x86\)/Arduino/ C:/Arduino
 ```
 
 After which, the variables should be:
 
 ```make
-    ARDUINO_DIR=../../../../../Arduino
+    ARDUINO_DIR=C:/Arduino
 ```
 
 Instead of:
 
 ```make
-    ARDUINO_DIR=../../../../../Program\ Files\ \(x86\)/Arduino
+    ARDUINO_DIR=C:/Program\ Files\ \(x86\)/Arduino
 ```
 
-Usefull Variables:
+### Usefull Variables
 
 The list of all variables that can be overridden is available at [arduino-mk-vars.md](arduino-mk-vars.md) file.
 
 - `BOARD_TAG` - Type of board, for a list see boards.txt or `make show_boards`
 - `MONITOR_PORT` - The port where your Arduino is plugged in, usually `/dev/ttyACM0` or `/dev/ttyUSB0` in Linux or Mac OS X and `com3`, `com4`, etc. in Windows.
-- `ARDUINO_DIR` - Path to Arduino installation. In Cygwin in Windows this path must be
-  relative, not absolute (e.g. "../../arduino" and not "/c/cygwin/Arduino").
-- `ARDMK_DIR`   - Path where the `*.mk` are present. If you installed the package, then it is usually `/usr/share/arduino`
+- `ARDUINO_DIR` - Path to Arduino installation. Using Windows with Cygwin,
+  this path must use Unix / and not Windows \\ (eg "C:/Arduino" not
+  "C:\\Arduino).
+- `ARDMK_DIR`   - Path where the `*.mk` are present. If you installed the package, then it is usually `/usr/share/arduino`. On Windows, this should be a path without spaces and no special characters, it can be a *cygdrive* path if nessessary and must use / not \\.
 - `AVR_TOOLS_DIR` - Path where the avr tools chain binaries are present. If you are going to use the binaries that came with Arduino installation, then you don't have to set it. Otherwise set it realtive and not absolute.
 
 

--- a/README.md
+++ b/README.md
@@ -205,16 +205,13 @@ On Windows (using Cygwin), you might want to set:
     # Symbolic link to Arduino installation directory - see below
     ARDUINO_DIR   = C:/Arduino
     ARDMK_DIR     = path/to/mkfile
-    ARDUINO_SKETCHBOOK = C:/Users/USERNAME/Documents/Arduino
     MONITOR_PORT  = com3
     BOARD_TAG     = mega2560
 ```
 
 **NOTE: Use forward slash not backslash and there should be no spaces or
 special characters in the Windows paths (due to Win/Unix crossover). The paths
-should not be *cygdrive* paths.** `ARDUINO_SKETCHBOOK` is defined to avoid
-automatic resolution, which resolve to *cygdrive* and is incompatable with the
-build tools.
+should not be *cygdrive* paths.**
 
 On Windows (using MSYS and PuTTY), you might want to set the following extra parameters:
 
@@ -262,7 +259,7 @@ Instead of:
     ARDUINO_DIR=C:/Program\ Files\ \(x86\)/Arduino
 ```
 
-### Usefull Variables
+### Useful Variables
 
 The list of all variables that can be overridden is available at [arduino-mk-vars.md](arduino-mk-vars.md) file.
 
@@ -271,8 +268,8 @@ The list of all variables that can be overridden is available at [arduino-mk-var
 - `ARDUINO_DIR` - Path to Arduino installation. Using Windows with Cygwin,
   this path must use Unix / and not Windows \\ (eg "C:/Arduino" not
   "C:\\Arduino).
-- `ARDMK_DIR`   - Path where the `*.mk` are present. If you installed the package, then it is usually `/usr/share/arduino`. On Windows, this should be a path without spaces and no special characters, it can be a *cygdrive* path if nessessary and must use / not \\.
-- `AVR_TOOLS_DIR` - Path where the avr tools chain binaries are present. If you are going to use the binaries that came with Arduino installation, then you don't have to set it. Otherwise set it realtive and not absolute.
+- `ARDMK_DIR`   - Path where the `*.mk` are present. If you installed the package, then it is usually `/usr/share/arduino`. On Windows, this should be a path without spaces and no special characters, it can be a *cygdrive* path if necessary and must use / not \\.
+- `AVR_TOOLS_DIR` - Path where the avr tools chain binaries are present. If you are going to use the binaries that came with Arduino installation, then you don't have to set it. Otherwise set it relative and not absolute.
 
 
 


### PR DESCRIPTION
Relates to issue https://github.com/sudar/Arduino-Makefile/issues/519

I've removed the requirement for relative paths from my own and the issues experience and been a bit more verbose on how to setup the Windows defines. 

I also added support for both the default Cygwin Unix style Python installation and a Windows Python installation (as many people including myself opt to use). The difference is that the Windows Python installation, expects the device port as a COMx (as passed by the user), not ttySx as the Arduino-Makefile currently detects Cygwin and passes. It does this by checking the binary path.

Windows is not my workstation of choice but I made these changes having to setup a work machine. It would be good to get it tested by some other Windows users.