### PR TITLE
Recognize serial monitors with full path in MONITOR_CMD

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1566,15 +1566,15 @@ show_submenu:
 	@$(CAT) $(BOARDS_TXT) | grep -E '[a-zA-Z0-9_\-]+.menu.(cpu|chip).[a-zA-Z0-9_\-]+=' | sort -uf | sed 's/.menu.\(cpu\|chip\)./:/' | sed 's/=/:/' | column -s: -t
 
 monitor:
-ifeq ($(MONITOR_CMD), 'putty')
+ifeq ($(notdir $(MONITOR_CMD)), putty)
 	ifneq ($(strip $(MONITOR_PARAMS)),)
 	$(MONITOR_CMD) -serial -sercfg $(MONITOR_BAUDRATE),$(MONITOR_PARAMS) $(call get_monitor_port)
 	else
 	$(MONITOR_CMD) -serial -sercfg $(MONITOR_BAUDRATE) $(call get_monitor_port)
 	endif
-else ifeq ($(MONITOR_CMD), picocom)
+else ifeq ($(notdir $(MONITOR_CMD)), picocom)
 		$(MONITOR_CMD) -b $(MONITOR_BAUDRATE) $(MONITOR_PARAMS) $(call get_monitor_port)
-else ifeq ($(MONITOR_CMD), cu)
+else ifeq ($(notdir $(MONITOR_CMD)), cu)
 		$(MONITOR_CMD) -l $(call get_monitor_port) -s $(MONITOR_BAUDRATE)
 else
 		$(MONITOR_CMD) $(call get_monitor_port) $(MONITOR_BAUDRATE)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 ### In Development
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)
 - Fix: Quote the prefix tag in the space_pad_to function
+- Fix: recognize serial monitors with full path in MONITOR_CMD
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - Tweak: Move non-standard-related items from CxxFLAGS_STD to CxxFLAGS (issue #523) (https://github.com/sej7278)
 - Tweak: Update Windows usage documentation and allow non-relative paths (issue #519) (https://github.com/tuna-f1sh)


### PR DESCRIPTION
When assembling the command line for the various supported serial
monitors, `MONITOR_CMD` must match the name of one of the supported
commands to be recognized.  Serial monitors given with leading path
components are not recognized, and a command like

  `make MONITOR_CMD=~/src/picocom/picocom monitor`

errors out as the fallback monitor command is executed instead of the
`picocom`-specific one.  However, sometimes it's necessary to specify a
supported serial monitor with its full path, because e.g. the user
wants to tests a freshly compiled version before installing it.  Sure,
the user could just run the serial monitor directly, but that's
cumbersome because he has to pay attention to use the right baud rate
and USB port.

So strip all leading path components, if present, from `MONITOR_CMD`
using the `nondir` make function before checking whether it's one of
the supported serial monitors.  This way commands like the above would
just work.