### PR TITLE
Set `ARDMK_VENDOR` differently if OS is Arch Linux.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -328,7 +328,12 @@ endif
 ########################################################################
 # 1.5.x vendor - defaults to arduino
 ifndef ARDMK_VENDOR
-	ARDMK_VENDOR = arduino
+    ARCH_LINUX := $(shell grep "Arch Linux" /etc/os-release 2>/dev/null)
+    ifdef ARCH_LINUX
+        ARDMK_VENDOR = archlinux-arduino
+    else
+        ARDMK_VENDOR = arduino
+    endif
     $(call show_config_variable,ARDMK_VENDOR,[DEFAULT])
 else
     $(call show_config_variable,ARDMK_VENDOR,[USER])


### PR DESCRIPTION
First of all, sorry for the noise. I [already made a PR](https://github.com/sudar/Arduino-Makefile/pull/531) for this branch but I accidentally closed it and I still want to discuss it and hopefully to see it merged.

Thanks.