### PR TITLE
Moved -e flag for avrdude from set_fuses to ispload

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1531,7 +1531,7 @@ reset_stty:
 		$$STTYF $(call get_monitor_port) -hupcl
 
 ispload:	$(TARGET_EEP) $(TARGET_HEX) verify_size
-		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) \
+		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) -e \
 			$(AVRDUDE_ISPLOAD_OPTS)
 
 burn_bootloader:
@@ -1547,7 +1547,7 @@ endif
 
 set_fuses:
 ifneq ($(strip $(AVRDUDE_ISP_FUSES_PRE)),)
-		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) -e $(AVRDUDE_ISP_FUSES_PRE)
+		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) $(AVRDUDE_ISP_FUSES_PRE)
 endif
 ifneq ($(strip $(AVRDUDE_ISP_FUSES_POST)),)
 		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) $(AVRDUDE_ISP_FUSES_POST)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)
 - Fix: Quote the prefix tag in the space_pad_to function
 - Fix: recognize serial monitors with full path in MONITOR_CMD
+- Tweak: Move chip erase flag from set_fuses to ispload to prevent sketch being nuked when setting fuses
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - Tweak: Move non-standard-related items from CxxFLAGS_STD to CxxFLAGS (issue #523) (https://github.com/sej7278)
 - Tweak: Update Windows usage documentation and allow non-relative paths (issue #519) (https://github.com/tuna-f1sh)


### PR DESCRIPTION
You wouldn't want a chip erase operation when only setting the fuses.

ispload probably should erase the flash+eeprom+lockbits as that's when you upload the sketch.

setting fuses should be just that, not deleting anything.

May help with issue #417 also

My use case is that I want to ispload a sketch, then set the hfuse to 0x5f which will prevent me from being able to ispload afterwards (it uses the reset pin as d5). This allows me to run set_fuses without nuking the script I uploaded with ispload.