### PR TITLE
Moved ATtiny examples from Blink to ATtinyBlink

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In Development
+- Fix: Moved ATtiny examples to ATtinyBlink, updated alternate core instructions (issue #537) (https://github.com/sej7278)
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)
 - Fix: Quote the prefix tag in the space_pad_to function
 - Fix: recognize serial monitors with full path in MONITOR_CMD

--- a/examples/ATtinyBlink/Makefile
+++ b/examples/ATtinyBlink/Makefile
@@ -1,13 +1,59 @@
 # Arduino Make file. Refer to https://github.com/sudar/Arduino-Makefile
 
-# if you have placed the alternate core in your sketchbook directory, then you can just mention the core name alone.
-ALTERNATE_CORE = attiny
-# If not, you might have to include the full path.
-#ALTERNATE_CORE_PATH = /home/sudar/Dropbox/code/arduino-sketches/hardware/attiny/
+# Set this if the IDE is not in your $PATH or you want to use a specific version:
+ARDUINO_DIR = $(HOME)/arduino-1.8.5
 
-BOARD_TAG    = attiny85-8
-ISP_PORT = /dev/ttyACM*
+# Programmer type:
+ISP_PROG = usbasp
 
-include $(ARDMK_DIR)/Arduino.mk
+# Examples - obviously pick only one and comment/delete the rest:
 
-# !!! Important. You have to use make ispload to upload when using ISP programmer
+# ------------------------------------------------------------------ #
+
+# https://github.com/SpenceKonde/ATTinyCore (1.5+)
+ALTERNATE_CORE = ATTinyCore
+BOARD_TAG = attinyx4
+BOARD_SUB = 84
+VARIANT = tinyX4
+F_CPU = 8000000L
+#BOARD_TAG = attinyx313
+#BOARD_SUB = 4313
+#BOARD_TAG = attinyx61
+#BOARD_SUB = 861
+#F_CPU = 8000000L
+
+# ------------------------------------------------------------------ #
+
+# https://github.com/Coding-Badly/TinyCore1 (1.5+)
+ALTERNATE_CORE = tiny
+BOARD_TAG = attiny85at8
+#BOARD_TAG = attiny2313at1
+
+# https://github.com/Coding-Badly/arduino-tiny (1.0)
+ALTERNATE_CORE = tiny
+BOARD_TAG = attiny85at8
+#BOARD_TAG = attiny44at8
+#BOARD_TAG = attiny84at8
+ARDUINO_VAR_PATH = $(HOME)/arduino/hardware/tiny/cores/tiny
+ARDUINO_CORE_PATH = $(HOME)/arduino/hardware/tiny/cores/tiny
+
+# ------------------------------------------------------------------ #
+
+# https://github.com/damellis/attiny (1.5+)
+ALTERNATE_CORE = attiny-master
+BOARD_TAG = attiny
+BOARD_SUB = attiny85
+F_CPU = 16000000L
+
+# https://github.com/damellis/attiny (1.0)
+ALTERNATE_CORE = attiny-master
+BOARD_TAG = attiny85
+#BOARD_TAG = attiny44-8
+#BOARD_TAG = attiny84-20
+
+# ------------------------------------------------------------------ #
+
+# Path to the Arduino Makefile
+include /usr/share/arduino/Arduino.mk
+
+# !!! Important. You have to use 'make ispload' when using an ISP.

--- a/examples/Blink/Makefile
+++ b/examples/Blink/Makefile
@@ -45,8 +45,8 @@ include ../../Arduino.mk
 #BOOTLOADER_PARENT = $(HOME)/arduino/hardware/promicro/bootloaders
 #BOOTLOADER_PATH   = caterina
 #BOOTLOADER_FILE   = Caterina-promicro16.hex
-#ISP_PROG     	   = usbasp
-#AVRDUDE_OPTS 	   = -v
+#ISP_PROG          = usbasp
+#AVRDUDE_OPTS      = -v
 #include /usr/share/arduino/Arduino.mk
 
 # --- chipkit
@@ -75,40 +75,8 @@ include ../../Arduino.mk
 #ARDUINO_DIR  = /where/you/installed/arduino-1.6.5
 #include /usr/share/arduino/Arduino.mk
 
-# --- arduino-tiny ide 1.0
-#ISP_PROG     	    = usbasp
-#BOARD_TAG          = attiny85at8
-#ALTERNATE_CORE     = tiny
-#ARDUINO_VAR_PATH   = $(HOME)/arduino/hardware/tiny/cores/tiny
-#ARDUINO_CORE_PATH  = $(HOME)/arduino/hardware/tiny/cores/tiny
-#AVRDUDE_OPTS 	    = -v
-#include /usr/share/arduino/Arduino.mk
-
-# --- arduino-tiny ide 1.6
-#ISP_PROG       = usbasp
-#BOARD_TAG      = attiny85at8
-#ALTERNATE_CORE = tiny
-#ARDUINO_DIR    = /where/you/installed/arduino-1.6.5
-#include /usr/share/arduino/Arduino.mk
-
-# --- damellis attiny ide 1.0
-#ISP_PROG       = usbasp
-#BOARD_TAG      = attiny85
-#ALTERNATE_CORE = attiny-master
-#AVRDUDE_OPTS   = -v
-#include /usr/share/arduino/Arduino.mk
-
-# --- damellis attiny ide 1.6
-#ISP_PROG       = usbasp
-#BOARD_TAG      = attiny
-#BOARD_SUB      = attiny85
-#ALTERNATE_CORE = attiny
-#F_CPU          = 16000000L
-#ARDUINO_DIR    = /where/you/installed/arduino-1.6.5
-#include /usr/share/arduino/Arduino.mk
-
 # --- teensy3
-#BOARD_TAG 	 = teensy31
+#BOARD_TAG   = teensy31
 #ARDUINO_DIR = /where/you/installed/the/patched/teensy/arduino-1.0.6
 #include /usr/share/arduino/Teensy.mk
 
@@ -118,8 +86,31 @@ include ../../Arduino.mk
 #BOOTLOADER_PARENT = $(HOME)/arduino/hardware/mighty-1284p/bootloaders
 #BOOTLOADER_PATH   = optiboot
 #BOOTLOADER_FILE   = optiboot_atmega1284p.hex
-#ISP_PROG     	   = usbasp
-#AVRDUDE_OPTS 	   = -v
+#ISP_PROG          = usbasp
+#AVRDUDE_OPTS      = -v
+#include /usr/share/arduino/Arduino.mk
+
+# --- mightycore
+#ALTERNATE_CORE = MightyCore
+#BOARD_TAG = 1284
+#MCU = atmega1284p
+#BOARD_TAG = 644
+#MCU = atmega644p
+#VARIANT = standard
+#F_CPU = 16000000L
+#include /usr/share/arduino/Arduino.mk
+
+# ---  megacore
+#BOARD_TAG      = 128
+#ALTERNATE_CORE = megacore
+#F_CPU          = 16000000L
+#include /usr/share/arduino/Arduino.mk
+
+# --- sanguino 644p
+#BOARD_TAG      = atmega644p
+#ALTERNATE_CORE = sanguino
+#ISP_PROG       = usbasp
+#AVRDUDE_OPTS   = -v
 #include /usr/share/arduino/Arduino.mk
 
 # --- atmega328p on breadboard


### PR DESCRIPTION
Also updated the instructions (issue #537).

Updated the alternate core instructions for e.g. ATmega644p for IDE 1.8