### PR TITLE
Allow compatibility with old pgmspace API to be disabled by the user

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1032,10 +1032,16 @@ else
 endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
-CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) $(ARDUINO_ARCH_FLAG) -D__PROG_TYPES_COMPAT__ \
+CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) $(ARDUINO_ARCH_FLAG) \
         -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections
+
+# PROG_TYPES_COMPAT is enabled by default for compatibility with the Arduino IDE.
+# By placing it before the user-provided CPPFLAGS rather than after, we allow the
+# the user to disable it if they like, by adding the negation of the flag
+# (-U__PROG_TYPES_COMPAT__) to the user-provided CPPFLAGS.
+CPPFLAGS := -D__PROG_TYPES_COMPAT__ $(CPPFLAGS)
 
 ifdef DEBUG
 OPTIMIZATION_FLAGS= $(DEBUG_FLAGS)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Add generation of tags file using ctags, which automatically includes project libs and Arduino core. (https://github.com/tuna-f1sh)
 - New: Add template Makefile and project boilerplate initialise script, `ardmk-init`. (https://github.com/tuna-f1sh)
 - New: Support atmelice_isp JTAG tool as ISP programmer. (https://github.com/tuna-f1sh)
+- New: Compatibility with deprecated pgmspace.h API can now be disabled since it sometimes causes bogus compiler warnings (issue #546)
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)


### PR DESCRIPTION
#169 added `-D__PROG_TYPES_COMPAT__` to the compiler flags, which enables compatibility with the old PROGMEM API (in which `PROGMEM` attributes were attached to types rather than variables). Usage of the old API raises compilation warnings about its deprecation, which is good.

Due to the fact that some symbols (`PGM_P` and `PGM_VOID_P` in particular) are common to both the old and new versions of the API but with differing implementations, code that uses only the new API can still raise bogus deprecation warnings if `__PROG_TYPES_COMPAT__` happens to be enabled.

Moreover, it would be better to encourage users to upgrade outdated code to the new interface than to maintain eternal compatibility with a deprecated API - the user should have to explicitly declare that they want to enable compatibility mode.

Therefore I propose that the default behaviour should be changed to leave `__PROG_TYPES_COMPAT__` unset. The user has the ability to re-enable it if they like, by adding

```makefile
CPPFLAGS += -D__PROG_TYPES_COMPAT__
```

to their Makefile.

Relatedly, is there a good place we could document this? I feel a FAQ-type section featuring the error message(s) that may require enabling `__PROG_TYPES_COMPAT__` would be a good fit for this, but I couldn't see a could place to put it.