### PR TITLE
Added the DIAGNOSTICS_COLOR_WHEN var for controlling diagnostics-color.

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1108,10 +1108,11 @@ endif
 CFLAGS        += $(CFLAGS_STD)
 CXXFLAGS      += -fpermissive -fno-exceptions $(CXXFLAGS_STD)
 ASFLAGS       += -x assembler-with-cpp
+DIAGNOSTICS_COLOR_WHEN ?= always
 ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
     ASFLAGS  += -flto
-    CXXFLAGS += -fno-threadsafe-statics -flto -fno-devirtualize -fdiagnostics-color
-    CFLAGS   += -flto -fno-fat-lto-objects -fdiagnostics-color
+    CXXFLAGS += -fno-threadsafe-statics -flto -fno-devirtualize -fdiagnostics-color=$(DIAGNOSTICS_COLOR_WHEN)
+    CFLAGS   += -flto -fno-fat-lto-objects -fdiagnostics-color=$(DIAGNOSTICS_COLOR_WHEN)
 endif
 LDFLAGS       += -$(MCU_FLAG_NAME)=$(MCU) -Wl,--gc-sections -O$(OPTIMIZATION_LEVEL)
 ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Tweak: Update Windows usage documentation and allow non-relative paths (issue #519) (https://github.com/tuna-f1sh)
 - Tweak: Support Cygwin Unix Python and Windows installation on Windows to pass correct port binding. (https://github.com/tuna-f1sh)
 - New: Added -fdiagnostics-color to \*STD flags (https://github.com/sej7278)
+- New: Made -fdiagnostics-color take a variiable DIAGNOSTICS_COLOR_WHEN: never, always, auto. (https://github.com/wingunder)
 - New: Add generation of tags file using ctags, which automatically includes project libs and Arduino core. (https://github.com/tuna-f1sh)
 - New: Add template Makefile and project boilerplate initialise script, `ardmk-init`. (https://github.com/tuna-f1sh)
 - New: Support atmelice_isp JTAG tool as ISP programmer. (https://github.com/tuna-f1sh)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -1047,7 +1047,7 @@ CXXFLAGS_STD = -std=gnu++98
 Flags passed to compiler for files compiled as C. Add more flags to this
 variable using `+=`.
 
-Defaults to `undefined` on 1.0 or `-flto -fno-fat-lto-objects -fdiagnostics-color` on AVR toolchain > 4.9.0 (e.g. IDE 1.6.10+)
+Defaults to `undefined` on 1.0 or `-flto -fno-fat-lto-objects -fdiagnostics-color=$(DIAGNOSTICS_COLOR_WHEN)` on AVR toolchain > 4.9.0 (e.g. IDE 1.6.10+)
 
 **Example:**
 
@@ -1074,6 +1074,30 @@ on AVR toolchain > 4.9.0 (e.g. IDE 1.6.10+)
 
 ```Makefile
 CXXFLAGS += -my-c++-onlyflag
+```
+
+**Requirement:** *Optional*
+
+----
+
+### DIAGNOSTICS_COLOR_WHEN
+
+**Description:**
+
+This variable controls the compiler's diagnostics-color setting, as defined
+in CFLAGS or CXXFLAGS, on AVR toolchain > 4.9.0.
+Supported values are: `always`, `never` and `auto`.
+For more details, see: [Options to Control Diagnostic Messages Formatting]
+(https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Language-Independent-Options.html#Language-Independent-Options)
+
+Defaults to `always`.
+
+**Example:**
+
+```Makefile
+DIAGNOSTICS_COLOR_WHEN = never
+# or
+DIAGNOSTICS_COLOR_WHEN = auto
 ```
 
 **Requirement:** *Optional*


### PR DESCRIPTION
Some IDEs do not work nicely with the recently added diagnostics-color
compiler switch. This patch adds the DIAGNOSTICS_COLOR_WHEN variable,
for controlling diagnostics-color switch. The default was chosen to be
'always', which makes the Arduino.mk file backwards compatible with
everything up to commit fa82c3a9db (Sat Sep 2 15:32:52 2017 +0100).

The supported values for DIAGNOSTICS_COLOR_WHEN are: `always`, `never`
and `auto`, and as with all Arduino.mk variables, it can easily be
overridden. For more details on the diagnostics-color compiler switch,
see: https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Language-Independent-Options.html#Language-Independent-Options