### PR TITLE
Change := to += to allow projects to add their own objs to OTHER_OBJS

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -844,7 +844,7 @@ ifeq ($(strip $(NO_CORE)),)
         # Put alt core variant file for M0 devices in OTHER_OJBS
         ifdef ALT_CORE_CPP_SRCS
             ALT_CORE_OBJ_FILES  = $(ALT_CORE_C_SRCS:.c=.c.o) $(ALT_CORE_CPP_SRCS:.cpp=.cpp.o) $(ALT_CORE_AS_SRCS:.S=.S.o)
-            OTHER_OBJS   := $(patsubst $(ALTERNATE_CORE_PATH)/variants/$(VARIANT)/%,  \
+            OTHER_OBJS  += $(patsubst $(ALTERNATE_CORE_PATH)/variants/$(VARIANT)/%,  \
                 $(OBJDIR)/core/%,$(ALT_CORE_OBJ_FILES))
         endif
 


### PR DESCRIPTION
OTHER_OBJS is an undocumented, but useful, way to add extra sources to
a project.  Setting it with := here breaks this functionality, so I've
changed it to += to not trample on the user-set value.