### PR TITLE
Support for Arduino Due added

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,7 +20,8 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Add template Makefile and project boilerplate initialise script, `ardmk-init`. (https://github.com/tuna-f1sh)
 - New: Support atmelice_isp JTAG tool as ISP programmer. (https://github.com/tuna-f1sh)
 - New: Compatibility with deprecated pgmspace.h API can now be disabled since it sometimes causes bogus compiler warnings (issue #546)
-- New: Support Arduino ARM-based (SAM/SAMD) devices. (https://github.com/tuna-f1sh)
+- New: Support Arduino ARM SAMD devices (Zero, M0 Pro, Feather M0). (https://github.com/tuna-f1sh)
+- New: Support Arduino ARM SAM devices (Due). (https://github.com/tuna-f1sh)
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a very simple Makefile which knows how to build Arduino sketches. It def
 - Highly customizable
 - Supports all official AVR-based Arduino boards
 - Supports official ARM-based Arduino boards using Atmel SAM chip family
-  (Cortex M0) and includes on-device debugging targets.
+and includes on-device debugging targets.
 - Supports chipKIT
 - Supports Teensy 3.x (via Teensyduino)
 - Works on all three major OS (Mac, Linux, Windows)
@@ -318,14 +318,14 @@ For large Robotis projects, [libmaple](https://github.com/Rhoban/Maple) may be m
 ## Arduino ARM Boards
 
 For Arduino boards using ARM architechure, specifically the Atmel SAM series
-(Arduino M0 [Pro], Zero, MKR1000, Feather M0, etc.), first
+((SAM3X8E) Due; (SAMD21) Arduino M0 [Pro], Zero, MKR1000, Feather M0, etc.), first
 install the board support package from the IDE or other distribution channels.
 
 Define`ARDUINO_PACKAGE_DIR` as the root path containing the ARM support
 package (the manufacturer folder) and the `BOARD_TAG` (see `make show_boards`
 for help) within your project Makefile. Include 'Sam.mk' rather than
-  'Arduino.mk' at the end of your file - see examples/ZeroBlink and
-  examples/MZeroBlink for example usage.
+  'Arduino.mk' at the end of your file - see examples/ZeroBlink,
+  examples/MZeroBlink and examples/DueBlink for example usage.
 
 **Note**: The Arduino IDE does not install board support packages to
 the base Arduino installation directory (the directory that will work with AVR
@@ -351,7 +351,7 @@ bootloaders. External CMSIS tools such as Atmel Ice will also work with this
 method. Black Magic Probe (BMP) support is also included using GDB for both
 uploading and debugging.
 
-Native USB programing using Bossa (Zero, MKR1000, Feather style bootloaders)
+Native USB programing using Bossa (Due, Zero, MKR1000, Feather style bootloaders)
 and avrdude (M0 bootloaders) is supported. The bootloaders on these devices
 requires a double press of the reset button or open/closing the serial port at
 1200 BAUD. The automatic entry of the bootloader is attempted using

--- a/examples/DueBlink/DueBlink.ino
+++ b/examples/DueBlink/DueBlink.ino
@@ -1,0 +1,19 @@
+/*
+  Blink
+  Turns on an LED on for one second, then off for one second, repeatedly.
+
+  This example code is in the public domain.
+ */
+
+void setup() {
+  // initialize the digital pin as an output.
+  // Pin 13 has an LED connected on most Arduino boards:
+  pinMode(13, OUTPUT);
+}
+
+void loop() {
+  digitalWrite(13, HIGH);   // set the LED on
+  delay(1000);              // wait for a second
+  digitalWrite(13, LOW);    // set the LED off
+  delay(1000);              // wait for a second
+}

--- a/examples/DueBlink/Makefile
+++ b/examples/DueBlink/Makefile
@@ -1,0 +1,19 @@
+# Arduino Due uses SAM3X8E SAM chip
+BOARD_TAG = arduino_due_x
+ARCHITECTURE = sam
+
+# Define ARM toolchain dir if not using Arduino supplied
+#ARM_TOOLS_DIR = /usr
+
+# Define AVR toolchain dir if not using Arduino supplied and using native port
+#AVR_TOOLS_DIR = /usr
+
+# Define Arduino support package installation path where SAM device support has been installed
+# Linux
+#ARDUINO_PACKAGE_DIR := $(HOME)/.arduino15/packages
+# macOS
+#ARDUINO_PACKAGE_DIR := $(HOME)/Library/Arduino15/packages
+# Windows
+#ARDUINO_PACKAGE_DIR := "C:/Users/$(USER)/AppData/Local/Arduino15/packages"
+
+include ../../Sam.mk

--- a/tests/script/runtests.sh
+++ b/tests/script/runtests.sh
@@ -7,7 +7,7 @@ failures=()
 # These examples cannot be tested easily at the moment as they require
 # alternate cores. The MakefileExample doesn't actually contain any source code
 # to compile.
-NON_TESTABLE_EXAMPLES=(ATtinyBlink MakefileExample TinySoftWareSerial BlinkOpenCM BlinkTeensy BlinkNetworkRPi BlinkInAVRC MZeroBlink ZeroBlink)
+NON_TESTABLE_EXAMPLES=(ATtinyBlink MakefileExample TinySoftWareSerial BlinkOpenCM BlinkTeensy BlinkNetworkRPi BlinkInAVRC MZeroBlink ZeroBlink DueBlink)
 
 for dir in $TESTS_DIR/*/
 do


### PR DESCRIPTION
Following on from #565 , support for Arduino Due added to complete Arduino SAM support. Fairly minor changes:

* Change from use of ALT_CORE_.. to SAM_CORE.. for readability as there is a bit more going on to pull together the core files on the Arduino Due. I don't think this has any impact as it was added in the original SAM pull request. 
* Catch empty CMSIS version detection to prevent `basename` flag complaining.
* Escape character on `grep` string to prevent macOS BSD grep complaining. 
* Blink example for Arduino Due