### PR TITLE
Arduino.mk: Fix clean target declaration

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1663,7 +1663,7 @@ ifneq ($(strip $(AVRDUDE_ISP_FUSES_POST)),)
 		$(AVRDUDE) $(AVRDUDE_COM_OPTS) $(AVRDUDE_ISP_OPTS) $(AVRDUDE_ISP_FUSES_POST)
 endif
 
-clean::
+clean:
 		$(REMOVE) $(OBJDIR)
 
 size:	$(TARGET_HEX)


### PR DESCRIPTION
Write clean: instead of clean::

This is needed on some systems

Change-Id: Ie9186b7c5b6920327846e42483f0299d42ce693b
Signed-off-by: Philippe Coval <p.coval@samsung.com>