### PR TITLE
Pass OpenOCD options to debug_init target

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1691,7 +1691,7 @@ else
 endif
 
 debug_init:
-	$(OPENOCD)
+	$(OPENOCD) $(OPENOCD_OPTS)
 
 debug:
 	$(GDB) $(GDB_OPTS)


### PR DESCRIPTION
The OpenOCD options are required to pass the configuration script for the target variant and start the debugger.