### PR TITLE
Fix "does not allow use of 'sudo'" error in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: c
 compiler:
   - gcc


### PR DESCRIPTION
Pull requests seem to fail with the following error:
> This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid, and setgid executables.
> If you require sudo, add 'sudo: required' to your .travis.yml

This commit fixes it, by adding 'sudo: required' to .travis.yml, as suggested by the error message.