### PR TITLE
Arduino.mk: added PRE_UPLOAD_HOOK macro to specify script to run befo…

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -623,6 +623,13 @@ else
     $(call show_config_variable,PRE_BUILD_HOOK,[USER])
 endif
 
+ifndef PRE_UPLOAD_HOOK
+    PRE_UPLOAD_HOOK = pre-upload-hook.sh
+    $(call show_config_variable,PRE_UPLOAD_HOOK,[DEFAULT])
+else
+    $(call show_config_variable,PRE_UPLOAD_HOOK,[USER])
+endif
+
 ########################################################################
 # boards.txt parsing
 
@@ -1441,7 +1448,7 @@ $(OBJDIR)/%.lss: $(OBJDIR)/%.elf $(COMMON_DEPS)
 
 $(OBJDIR)/%.sym: $(OBJDIR)/%.elf $(COMMON_DEPS)
 	@$(MKDIR) $(dir $@)
-	$(NM) --size-sort --demangle --reverse-sort --line-numbers $< > $@
+	$(NM) $(AVR_SIZE_OPTS) --size-sort --demangle --reverse-sort --line-numbers $< > $@
 
 ########################################################################
 # Ctags
@@ -1621,7 +1628,7 @@ error_on_caterina:
 
 # Use submake so we can guarantee the reset happens
 # before the upload, even with make -j
-upload:		$(TARGET_HEX) verify_size
+upload:		$(TARGET_HEX) pre-upload verify_size
 ifeq ($(findstring sam, $(strip $(ARCHITECTURE))), sam)
 # do reset toggle at 1200 BAUD to enter bootloader if using avrdude or bossa
 ifeq ($(strip $(UPLOAD_TOOL)), avrdude)
@@ -1634,6 +1641,9 @@ else
 		$(MAKE) reset
 		$(MAKE) do_upload
 endif
+
+pre-upload:
+		$(call runscript_if_exists,$(PRE_UPLOAD_HOOK))
 
 raw_upload:	$(TARGET_HEX) verify_size
 ifeq ($(findstring sam, $(strip $(ARCHITECTURE))), sam)
@@ -1827,7 +1837,8 @@ help:
 
 .PHONY: all upload raw_upload raw_eeprom error_on_caterina reset reset_stty ispload \
         clean depends size show_boards monitor disasm symbol_sizes generated_assembly \
-        generate_assembly verify_size burn_bootloader help pre-build tags debug debug_init
+        generate_assembly verify_size burn_bootloader help pre-build tags debug debug_init \
+				pre-upload
 
 # added - in the beginning, so that we don't get an error if the file is not present
 -include $(DEPS)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -1239,6 +1239,23 @@ PRE_BUILD_HOOK = $(HOME)/bin/bump-revision.sh
 
 **Requirement:** *Optional*
 
+### PRE_UPLOAD_HOOK
+
+**Description:**
+
+Path to shell script to be executed before uploading. Could be used to automatically
+last minute modification just before uploading code to chip.
+
+Defaults to `pre-upload-hook.sh`
+
+**Example:**
+
+```Makefile
+PRE_UPLOAD_HOOK = $(HOME)/bin/upload-revision.sh
+```
+
+**Requirement:** *Optional*
+
 ----
 
 ## Avrdude setting variables


### PR DESCRIPTION
I have added a PRE_UPLOAD_HOOK macro and a new phony target in Arduino.mk (pre-upload) to execute a shell script just before uploading the code to the chip.
Also modified arduino-mk-vars.md to the description of the PRE_UPLOAD_HOOK


added AVR_SIZE_OPTS when using $(NM) to dump symbols,
[taret upload]: added prerequestive pre-upload in order to execute the PRE_UPLOAD_HOOK script,
[added target pre-upload] to execute PRE_UPLOAD_HOOK script,
[.PHONY]: added target pre-upload,
arduino-mk-vars.md: added description for PRE_UPLOAD_HOOK