### PR TITLE
allow to enable AVRDUDE_AUTOERASE_FLASH

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1490,7 +1490,11 @@ endif
 # -D - Disable auto erase for flash memory
 # Note: -D is needed for Mega boards.
 #       (See https://github.com/sudar/Arduino-Makefile/issues/114#issuecomment-25011005)
-AVRDUDE_ARD_OPTS = -D -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
+ifeq ($(AVRDUDE_AUTOERASE_FLASH), yes)
+else
+    AVRDUDE_ARD_OPTS = -D
+endif
+AVRDUDE_ARD_OPTS += -c $(AVRDUDE_ARD_PROGRAMMER) -b $(AVRDUDE_ARD_BAUDRATE) -P
 ifeq ($(CURRENT_OS), WINDOWS)
     # get_monitor_port checks to see if the monitor port exists, assuming it is
     # a file. In Windows, avrdude needs the port in the format 'com1' which is

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -1281,6 +1281,24 @@ AVRDUDE_CONF = /usr/share/arduino/hardware/tools/avrdude.conf
 
 ----
 
+### AVRDUDE_AUTOERASE_FLASH
+
+**Description:**
+
+Enable autoerase flash.
+
+By default disabled.
+
+**Example:**
+
+```Makefile
+AVRDUDE_AUTOERASE_FLASH = yes
+```
+
+**Requirement:** *Optional*
+
+----
+
 ### AVR_TOOLS_PATH
 
 **Description:**


### PR DESCRIPTION
I using usbasp to program atmega328p barebone so I disabled ard-reset-arduino by declaring `RESET_CMD = echo` ; btw I got problem flashing image within -D option of avrdude enabled, so I introduced this option AVRDUDE_AUTOERASE_FLASH=yes to allow inhibit (default) deactivation of autoerase flash.