### PR TITLE
Add support for BOARD_CLOCK setting

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -641,9 +641,9 @@ else
     $(call show_config_variable,BOARD_TAG,[USER])
 endif
 
-ifdef BOARD_SPEED
-    BOARD_SPEED := $(strip $(BOARD_SPEED))
-    $(call show_config_variable,BOARD_SPEED,[USER])
+ifdef BOARD_CLOCK
+    BOARD_CLOCK := $(strip $(BOARD_CLOCK))
+    $(call show_config_variable,BOARD_CLOCK,[USER])
 endif
 
 # If NO_CORE is set, then we don't have to parse boards.txt file
@@ -691,8 +691,8 @@ ifeq ($(strip $(NO_CORE)),)
     endif
 
     ifndef F_CPU
-        ifdef BOARD_SPEED
-            F_CPU := $(call PARSE_BOARD,$(BOARD_TAG),menu.speed.$(BOARD_SPEED).build.f_cpu)
+        ifdef BOARD_CLOCK
+            F_CPU := $(call PARSE_BOARD,$(BOARD_TAG),menu.(speed|clock).$(BOARD_CLOCK).build.f_cpu)
         endif
         ifndef F_CPU
             F_CPU := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).build.f_cpu)
@@ -741,21 +741,36 @@ ifeq ($(strip $(NO_CORE)),)
     endif
 
     ifndef ISP_HIGH_FUSE
-        ISP_HIGH_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).bootloader.high_fuses)
+        ifdef BOARD_CLOCK
+            ISP_HIGH_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(speed|clock).$(BOARD_CLOCK).bootloader.high_fuses)
+        endif
+        ifndef ISP_HIGH_FUSE
+            ISP_HIGH_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).bootloader.high_fuses)
+        endif
         ifndef ISP_HIGH_FUSE
             ISP_HIGH_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),bootloader.high_fuses)
         endif
     endif
 
     ifndef ISP_LOW_FUSE
-        ISP_LOW_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).bootloader.low_fuses)
+        ifdef BOARD_CLOCK
+            ISP_LOW_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(speed|clock).$(BOARD_CLOCK).bootloader.low_fuses)
+        endif
+        ifndef ISP_LOW_FUSE
+            ISP_LOW_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).bootloader.low_fuses)
+        endif
         ifndef ISP_LOW_FUSE
             ISP_LOW_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),bootloader.low_fuses)
         endif
     endif
 
     ifndef ISP_EXT_FUSE
-        ISP_EXT_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).bootloader.extended_fuses)
+        ifdef BOARD_CLOCK
+            ISP_EXT_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(speed|clock).$(BOARD_CLOCK).bootloader.extended_fuses)
+        endif
+        ifndef ISP_EXT_FUSE
+            ISP_EXT_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).bootloader.extended_fuses)
+        endif
         ifndef ISP_EXT_FUSE
             ISP_EXT_FUSE := $(call PARSE_BOARD,$(BOARD_TAG),bootloader.extended_fuses)
         endif

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -641,6 +641,11 @@ else
     $(call show_config_variable,BOARD_TAG,[USER])
 endif
 
+ifdef BOARD_SPEED
+    BOARD_SPEED := $(strip $(BOARD_SPEED))
+    $(call show_config_variable,BOARD_SPEED,[USER])
+endif
+
 # If NO_CORE is set, then we don't have to parse boards.txt file
 # But the user might have to define MCU, F_CPU etc
 ifeq ($(strip $(NO_CORE)),)
@@ -686,7 +691,12 @@ ifeq ($(strip $(NO_CORE)),)
     endif
 
     ifndef F_CPU
-        F_CPU := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).build.f_cpu)
+        ifdef BOARD_SPEED
+            F_CPU := $(call PARSE_BOARD,$(BOARD_TAG),menu.speed.$(BOARD_SPEED).build.f_cpu)
+        endif
+        ifndef F_CPU
+            F_CPU := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).build.f_cpu)
+        endif
         ifndef F_CPU
             F_CPU := $(call PARSE_BOARD,$(BOARD_TAG),build.f_cpu)
         endif

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In Development
+- Tweak: Add support for BOARD_SPEED for board.menu.speed entries in boards.txt files. (https://github.com/dewhisna)
 - Fix: Moved CORE_LIB to the last position of the defined linked objects. (https://github.com/wingunder)
 - Fix: Moved ATtiny examples to ATtinyBlink, updated alternate core instructions (issue #537) (https://github.com/sej7278)
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ The following is the rough list of changes that went into different versions.
 I tried to give credit whenever possible. If I have missed anyone, kindly add it to the list.
 
 ### In Development
-- Tweak: Add support for BOARD_SPEED for board.menu.speed entries in boards.txt files. (https://github.com/dewhisna)
+- New: Add support for BOARD_CLOCK for board.menu.speed and board.menu.clock entries in boards.txt files. (https://github.com/dewhisna)
 - Fix: Moved CORE_LIB to the last position of the defined linked objects. (https://github.com/wingunder)
 - Fix: Moved ATtiny examples to ATtinyBlink, updated alternate core instructions (issue #537) (https://github.com/sej7278)
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -344,6 +344,24 @@ BOARD_SUB=atmega168
 
 ----
 
+### BOARD_SPEED
+
+**Description:**
+
+Allow selection of f_cpu value specified in `boards.txt` as `board_tag.menu.speed.board_speed`.
+For example, the Watterott ATmega328PB library [https://github.com/watterott/ATmega328PB-Testing](https://github.com/watterott/ATmega328PB-Testing).
+
+**Example:**
+
+```Makefile
+# Select 20MHz clock
+BOARD_SPEED=20mhz
+```
+
+**Requirement:** *Optional to override main board f_cpu setting*
+
+----
+
 ### MONITOR_PORT
 
 **Description:**

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -344,21 +344,30 @@ BOARD_SUB=atmega168
 
 ----
 
-### BOARD_SPEED
+### BOARD_CLOCK
 
 **Description:**
 
-Allow selection of f_cpu value specified in `boards.txt` as `board_tag.menu.speed.board_speed`.
+Allow selection of f_cpu and fuses specified in `boards.txt` as `{BOARD_TAG}.menu.clock.{BOARD_CLOCK}`.
+This works for microprocessor board definitions like ATtiny that specify not only the clock speed but fuse settings as clock overrides.
+
+It also works for f_cpu values specified in `boards.txt` as `{BOARD_TAG}.menu.speed.{BOARD_CLOCK}`.
 For example, the Watterott ATmega328PB library [https://github.com/watterott/ATmega328PB-Testing](https://github.com/watterott/ATmega328PB-Testing).
 
 **Example:**
 
 ```Makefile
-# Select 20MHz clock
-BOARD_SPEED=20mhz
+# Select external 16 MHz clock
+BOARD_CLOCK=external16
 ```
 
-**Requirement:** *Optional to override main board f_cpu setting*
+**Example:**
+```Makefile
+# Select 20MHz speed
+BOARD_CLOCK=20mhz
+```
+
+**Requirement:** *Optional to override main board f_cpu and/or fuse settings.*
 
 ----
 


### PR DESCRIPTION
This is needed to specify CPU speed for boards.txt files that use this format:
`{board_tag}.menu.speed.{board_speed}.build.f_cpu`
For example, the Watterott ATmega328PB library: https://github.com/watterott/ATmega328PB-Testing
