### PR TITLE
Fix #594 and sam flag for ardmk-init

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -716,6 +716,22 @@ ifeq ($(strip $(NO_CORE)),)
             endif
         endif
 
+        ifndef USB_PRODUCT
+            USB_PRODUCT := $(call PARSE_BOARD,$(BOARD_TAG),build.usb_product)
+            ifdef USB_PRODUCT
+                $(call show_config_variable,USB_PRODUCT,[COMPUTED])
+            endif
+        endif
+
+        ifndef USB_MANUFACTURER
+            USB_MANUFACTURER := $(call PARSE_BOARD,$(BOARD_TAG),build.usb_manufacturer)
+            ifndef USB_MANUFACTURER
+                USB_MANUFACTURER = "Unknown"
+            else
+                $(call show_config_variable,USB_MANUFACTURER,[COMPUTED])
+            endif
+        endif
+
         # add caterina flag to ARD_RESET_OPTS
         ARD_RESET_OPTS += --caterina
     endif
@@ -1161,6 +1177,9 @@ CPPFLAGS += $(OPTIMIZATION_FLAGS)
 # USB IDs for the Caterina devices like leonardo or micro
 ifneq ($(CATERINA),)
     CPPFLAGS += -DUSB_VID=$(USB_VID) -DUSB_PID=$(USB_PID)
+    ifdef USB_PRODUCT
+        CPPFLAGS += -DUSB_PRODUCT='$(USB_PRODUCT)' -DUSB_MANUFACTURER='$(USB_MANUFACTURER)'
+    endif
 endif
 
 # $(TOOL_PREFIX)-gcc version that we can do maths on

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Add -fno-devirtualize flag to workaround g++ segfault bug (issue #486). (https://github.com/sej7278)
 - Fix: Quote the prefix tag in the space_pad_to function
 - Fix: recognize serial monitors with full path in MONITOR_CMD
+- Fix: Grab USB_PRODUCT and USB_MANUFACTURER from boards.txt for 32u4 boards (issue #594).
 - Tweak: Move chip erase flag from set_fuses to ispload to prevent sketch being nuked when setting fuses
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - Tweak: Move non-standard-related items from CxxFLAGS_STD to CxxFLAGS (issue #523) (https://github.com/sej7278)

--- a/bin/ardmk-init
+++ b/bin/ardmk-init
@@ -22,7 +22,7 @@ import os
 import argparse
 
 ## Global Vars
-VERSION = "1.1"
+VERSION = "1.2"
 ARD_TEMPLATE = "\n\
 #include <Arduino.h>\n\
 #include <Wire.h>\n\
@@ -49,6 +49,7 @@ PARSER.add_argument('-u', '--micro', default='AUTO', help='microcontroller on bo
 PARSER.add_argument('-f', '--freq', default='AUTO', help='clock frequency')
 PARSER.add_argument('-p', '--port', default='AUTO', help='monitor port')
 PARSER.add_argument('-n', '--name', default=os.path.basename(os.getcwd()), help='project name')
+PARSER.add_argument('-s', '--sam', action='store_true', help='sam device, will include Sam.mk rather than Arduino.mk')
 PARSER.add_argument('--cli', action='store_true', help='run with user prompts (requires "Clint" module), rather than args')
 PARSER.add_argument('-P', '--project', action='store_true',
                     help='create boilerplate project with src, lib and bin folder structure')
@@ -182,7 +183,10 @@ def generate_makefile():
                                  validators=[validators.PathValidator()])
             ardmk = "ARDMK_DIR := " + ardmk + "\n"
 
-    file_content += "\ninclude $(ARDMK_DIR)/Arduino.mk"
+    if ARGS.sam:
+        file_content += "\ninclude $(ARDMK_DIR)/Sam.mk"
+    else:
+        file_content += "\ninclude $(ARDMK_DIR)/Arduino.mk"
 
     # Add forward slash if source directory exists
     if src_dir:


### PR DESCRIPTION
The fix for #594 to grab USB_PRODUCT and USB_MANUFACTURER from the boards.txt for Caterina (32u4) boards.

It also includes an additional flag (--sam) to `ardmk-init`, to configure for sam devices (include Sam.mk not Arduino.mk). I can separate if necessary but it seemed minor enough to include.