### PR TITLE
Build the ArduinoCore API

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -925,6 +925,10 @@ ifeq ($(strip $(NO_CORE)),)
         CORE_CPP_SRCS   = $(wildcard $(ARDUINO_CORE_PATH)/*.cpp)
         CORE_AS_SRCS    = $(wildcard $(ARDUINO_CORE_PATH)/*.S)
 
+        # ArduinoCore-API
+        CORE_C_SRCS    += $(wildcard $(ARDUINO_CORE_PATH)/api/*.c)
+        CORE_CPP_SRCS  += $(wildcard $(ARDUINO_CORE_PATH)/api/*.cpp)
+
         # USB Core if samd or sam
         ifeq ($(findstring sam, $(strip $(ARCHITECTURE))), sam)
             CORE_C_SRCS    += $(wildcard $(ARDUINO_CORE_PATH)/avr/*.c) # avr core emulation files
@@ -1159,7 +1163,7 @@ endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
 CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) $(ARDUINO_ARCH_FLAG) \
-        -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
+        -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_CORE_PATH)/api -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Add support for BOARD_CLOCK for board.menu.speed and board.menu.clock entries in boards.txt files. (https://github.com/dewhisna)
 - New: Updated Arch instructions. (https://github.com/Akram-Chehaima)
 - New: Add support for Robotis OpenCR 1.0 boards.
+- New: Build the ArduinoCore API
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)


### PR DESCRIPTION
As part of the big modularizing efforts of the Arduino project they
split out the hardware-independent layer of the Arduino "language"
from the hardware-specific cores into the dedicated 'ArduinoCore-API'
repository.  As described in 'ArduinoCore-API's README, the API source
files won't reside directly in the directory of the standard Arduino
core, i.e. in 'ARDUINO_CORE_PATH', but in its 'ARDUINO_CORE_PATH/api'
subdirectory.  Consequently, Arduino-Makefile won't be able to build
any projects when using an Arduino core following the new directory
structure.

Prepare for the upcoming new Arduino core directory structure by
building all 'ARDUINO_CORE_PATH/api/*.cpp' source files as well.  Out
of caution, look out for and build any .c source files in that
directory, too: though there are no .c source files in the
'ArduinoCore-API' repository at the moment, in the future there might
be.

Note that a 'make clean' will be most likely necessary when
re-building a project after switching to the new directory structure.

Update: there was a bit of a grammar glitch in the commit message, hence the force-push.