### PR TITLE
Fixed typo in variable name BOARDS_TXT in Sam.mk

### DIFF
--- a/Sam.mk
+++ b/Sam.mk
@@ -114,7 +114,7 @@ endif
 ifndef ARDUINO_CORE_PATH
     ARDUINO_CORE_PATH   = $(ALTERNATE_CORE_PATH)/cores/arduino
 endif
-ifndef BOARD_TXT
+ifndef BOARDS_TXT
     BOARDS_TXT          = $(ALTERNATE_CORE_PATH)/boards.txt
 endif
 


### PR DESCRIPTION
Variable BOARDS_TXT was typoed as BOARD_TXT on line 117