### PR TITLE
add swtich for ARM 'avr-size' so that .elf is passed as arg

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1286,9 +1286,14 @@ ifneq (,$(findstring AVR,$(shell $(SIZE) --help)))
     avr_size = $(SIZE) $(SIZEFLAGS) --format=avr $(1)
     $(call show_config_info,Size utility: AVR-aware for enhanced output,[AUTODETECTED])
 else
-    # We have a plain-old binutils version - just give it the hex.
-    avr_size = $(SIZE) $(2)
-    $(call show_config_info,Size utility: Basic (not AVR-aware),[AUTODETECTED])
+    ifeq ($(findstring sam, $(strip $(ARCHITECTURE))), sam)
+       avr_size = $(SIZE) $(SIZEFLAGS) $(1)
+       $(call show_config_info,Size utility: ARM,[AUTODETECTED])
+    else
+       # We have a plain-old binutils version - just give it the hex.
+       avr_size = $(SIZE) $(2)
+       $(call show_config_info,Size utility: Basic (not AVR-aware),[AUTODETECTED])
+    endif
 endif
 
 ifneq (,$(strip $(ARDUINO_LIBS)))

--- a/Sam.mk
+++ b/Sam.mk
@@ -395,12 +395,7 @@ ifndef BOOTLOADER_PROTECT_VERIFY
     endif
 endif
 
-# C99 with GNU extensions required for C sources using old compiler
-CC_VERNUM = $(shell $(CC) -dumpversion | sed 's/\.//g')
-ifneq ($(shell expr $(CC_VERNUM) '>' 490), 1)
-    CFLAGS_STD        = -std=gnu99
-endif
-
+CFLAGS_STD += -std=gnu11
 CPPFLAGS += -DMD -D$(USB_TYPE) '-DUSB_PRODUCT=$(USB_PRODUCT)' '-DUSB_MANUFACTURER=$(USB_MANUFACTURER)'
 
 # Get extra define flags from boards.txt
@@ -413,6 +408,10 @@ CPPFLAGS += -DUSB_PID=$(USB_PID)
 # Cortex compiler flags
 CPPFLAGS += -mthumb -nostdlib --param max-inline-insns-single=500 -fno-exceptions -Wl,-Map=$(OBJDIR)/$(TARGET).map
 CXXFLAGS += -fno-rtti -fno-threadsafe-statics -std=gnu++11
+
+ifndef SIZEFLAGS
+    SIZEFLAGS += -B
+endif
 
 AMCU := $(call PARSE_BOARD,$(BOARD_TAG),build.mcu)
 BOARD_LINKER_SCRIPT := $(call PARSE_BOARD,$(BOARD_TAG),build.ldscript)


### PR DESCRIPTION
`avr-size` was defaulting to AVR non-aware when using ARM builds, which meant passing .hex rather than .elf to size and limiting size readout.

Adding a switch for defining `avr-size` and SIZEFLAGS to Sam.mk seems like the best way to include proper ARM support (despite counter-intuitive naming).

I also corrected the GNU extensions flag to gnu11 to match the Arduino arm support as it was now failing to compile wiring.c