### PR TITLE
Fix regression: PARSE_BOARD chops off flags which contain '=' signs

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -5,16 +5,14 @@ COMMON_INCLUDED = TRUE
 # (directory and optional filename) exists
 dir_if_exists = $(if $(wildcard $(1)$(2)),$(1))
 
-ifndef PARSE_BOARD
 # result = $(call READ_BOARD_TXT, 'boardname', 'parameter')
 PARSE_BOARD = $(shell if [ -f $(BOARDS_TXT) ]; \
 then \
   grep -Ev '^\#' $(BOARDS_TXT) | \
   grep -E "^[ \t]*$(1).$(2)=" | \
-  cut -d = -f 2 | \
+  cut -d = -f 2- | \
   cut -d : -f 2; \
 fi)
-endif
 
 # Run a shell script if it exists. Stops make on error.
 runscript_if_exists =                                                          \

--- a/Sam.mk
+++ b/Sam.mk
@@ -130,11 +130,6 @@ CPPFLAGS += -I$(CMSIS_ATMEL_DIR)/Device/ATMEL
 LIB_PATH  =  $(CMSIS_DIR)/Lib/GCC
 BOOTLOADER_PARENT = $(ALTERNATE_CORE_PATH)/bootloaders
 
-# Utility from ard-mk to parse boards.txt for flags
-ifndef PARSE_BOARD
-    PARSE_BOARD = $(shell grep -Ev '^\#' $(BOARDS_TXT) | grep -E '^[ \t]*$(1).$(2)=' | cut -d = -f 2 | cut -d : -f 2)
-endif
-
 ifndef VARIANT
     VARIANT := $(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).build.variant)
     ifndef VARIANT


### PR DESCRIPTION
See #601