### PR TITLE
Show the configuration when ARDUINO_QUIET=0

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -241,6 +241,9 @@ arduino_output =
 # running for the first time (i.e., not after a restart after
 # regenerating the dependency file), then output the configuration.
 ifndef ARDUINO_QUIET
+    ARDUINO_QUIET = 0
+endif
+ifeq ($(ARDUINO_QUIET),0)
     ifeq ($(MAKE_RESTARTS),)
         ifeq ($(MAKELEVEL),0)
             arduino_output = $(info $(1))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Quote the prefix tag in the space_pad_to function
 - Fix: recognize serial monitors with full path in MONITOR_CMD
 - Fix: Grab USB_PRODUCT and USB_MANUFACTURER from boards.txt for 32u4 boards (issue #594).
+- Fix: Show the configuration when ARDUINO_QUIET=0
 - Tweak: Move chip erase flag from set_fuses to ispload to prevent sketch being nuked when setting fuses
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - Tweak: Move non-standard-related items from CxxFLAGS_STD to CxxFLAGS (issue #523) (https://github.com/sej7278)


### PR DESCRIPTION
There is a bit of inconsistency between documentation and code
regarding the ARDUINO_QUIET variable: 'arduino-mk-vars.md' states
that ARDUINO_QUIET "Defaults to `0` (unset/disabled)", but the code
only checks whether it's defined or not, and doesn't check whether
it's set to '0' or something else.

Consequently, having 'ARDUINO_QUIET=0' in the Makefile or running
'make ARDUINO_QUIET=0' contadicts the documentation and doesn't print
the configuration.  It also means that if someone in general prefers
not to see a screenful of configuration on each build and therefore
has 'ARDUINO_QUIET = 1' in the project's Makefile or 'config.mak',
then there is no way to override it from the command line in the odd
case when showing the configuration is desired.

Modify the corresponding condition in Arduino.mk to check whether
ARDUINO_QUIET is set to 0 and treat an undefined ARDUINO_QUIET
variable as "set to 0" as well.