### PR TITLE
Added api subdirectory to $ARDUINO_CORE_PATH for new cores like megaavr

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -925,6 +925,10 @@ ifeq ($(strip $(NO_CORE)),)
         CORE_CPP_SRCS   = $(wildcard $(ARDUINO_CORE_PATH)/*.cpp)
         CORE_AS_SRCS    = $(wildcard $(ARDUINO_CORE_PATH)/*.S)
 
+        # ArduinoCore-API
+        CORE_C_SRCS    += $(wildcard $(ARDUINO_CORE_PATH)/api/*.c)
+        CORE_CPP_SRCS  += $(wildcard $(ARDUINO_CORE_PATH)/api/*.cpp)
+
         # USB Core if samd or sam
         ifeq ($(findstring sam, $(strip $(ARCHITECTURE))), sam)
             CORE_C_SRCS    += $(wildcard $(ARDUINO_CORE_PATH)/avr/*.c) # avr core emulation files

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1159,7 +1159,7 @@ endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
 CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) $(ARDUINO_ARCH_FLAG) \
-        -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
+        -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_CORE_PATH)/api -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Add support for BOARD_CLOCK for board.menu.speed and board.menu.clock entries in boards.txt files. (https://github.com/dewhisna)
 - New: Updated Arch instructions. (https://github.com/Akram-Chehaima)
 - New: Add support for Robotis OpenCR 1.0 boards.
+- New: Added api subdirectory to ARDUINO_CORE_PATH for new ArduinoCore-API cores like megaavr (issue #607) (https://github.com/sej7278)
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)


### PR DESCRIPTION
seems to work fine even with cores where there is no api subdirectory