### PR TITLE
Fixed syntax error of make monitor on windows/cygwin

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1792,11 +1792,11 @@ show_submenu:
 
 monitor:
 ifeq ($(notdir $(MONITOR_CMD)), putty)
-	ifneq ($(strip $(MONITOR_PARAMS)),)
+ifneq ($(strip $(MONITOR_PARAMS)),)
 	$(MONITOR_CMD) -serial -sercfg $(MONITOR_BAUDRATE),$(MONITOR_PARAMS) $(call get_monitor_port)
-	else
+else
 	$(MONITOR_CMD) -serial -sercfg $(MONITOR_BAUDRATE) $(call get_monitor_port)
-	endif
+endif
 else ifeq ($(notdir $(MONITOR_CMD)), picocom)
 		$(MONITOR_CMD) -b $(MONITOR_BAUDRATE) $(MONITOR_PARAMS) $(call get_monitor_port)
 else ifeq ($(notdir $(MONITOR_CMD)), cu)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -43,6 +43,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Add support for good old cu as monitor command (issue #492) (https://github.com/mwm)
 - New: Add a documentation how to setup Makefile for 3rd party boards (issue #499). (https://github.com/MilanV)
 - New: Add support for Robotis OpenCM boards
+- Fix: Syntax of inner conditional statements of monitor command evaluated when MONITOR_CMD = putty
 
 ### 1.5.2 (2017-01-11)
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ sudo port install py27-serial
 
 On Windows:
 
-You need to install Cygwin and its packages for Make, Perl and the following Serial library.
+You need to install Cygwin and its packages for Make, Perl, Python2 and the following Serial library.
 
 Assuming you included Python in your Cygwin installation:
 
@@ -226,7 +226,7 @@ On Windows (using MSYS and PuTTY), you might want to set the following extra par
 
 ```make
     MONITOR_CMD   = putty
-    MONITOR_PARMS = 8,1,n,N
+    MONITOR_PARAMS = 8,1,n,N
 ```
 
 On Arduino 1.5+ installs, you should set the architecture to either `avr` or `sam` and if using a submenu CPU type, then also set that:

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -1249,6 +1249,24 @@ MONITOR_CMD = minicom
 
 ----
 
+### MONITOR_PARAMS
+
+**Description:**
+
+Additional parameters for the putty -sercfg command line argument.
+
+Interpreted as a comma-separated list of configuration options.
+
+**Example:**
+
+```Makefile
+MONITOR_PARAMS = 8,1,n,N
+```
+
+**Requirement:** *Optional*
+
+----
+
 ### PRE_BUILD_HOOK
 
 **Description:**


### PR DESCRIPTION
There was an issue when using the make monitor command on windows/cygwin setup when you specified the MONITOR_CMD variable to be putty and also specified the MONITOR_PARAMS variable.

Using the following makefile:
```
# Arduino Make file. Refer to https://github.com/sudar/Arduino-Makefile

# Path to arduino IDE 1.x.x installation folder 
ARDUINO_DIR   = D:/Arduino
BOARD_TXT	= D:/Arduino/hardware/arduino/avr
MONITOR_PORT	= com4


# Used for other arduino models (use `make show_submenu`)
# BOARD_SUB 		= 

#
# Common
#

ARDMK_DIR 		= ../setup/Arduino-Makefile
BOARD_TAG 		= uno
ARCHITECTURE	= avr
USER_LIB_PATH	= ../lib
OBJDIR			= ../bin

# for windows monitor
MONITOR_CMD   = putty
MONITOR_PARAMS = 8,1,n,N

# Space seperated list of included libraries
# ARDUINO_LIBS	= 
# From sudar's repo, main Makefile that compiles and uploads to Arduino
include $(ARDMK_DIR)/Arduino.mk
```

The following error would be raised:
```
ifneq (8,1,n,N,)
/bin/sh: -c: line 0: syntax error near unexpected token `8,1,n,N,'
/bin/sh: -c: line 0: `ifneq (8,1,n,N,)'
make: *** [../setup/Arduino-Makefile/Arduino.mk:1795: monitor] Error 1
```

This issue was due to the indentation of the inner conditional statements here:
https://github.com/sudar/Arduino-Makefile/blob/0e462fcff173c0e6963f3b23ecb5fbb2e59737e7/Arduino.mk#L1793-L1799

The GNU make documentation says this:
"Extra spaces are allowed and ignored at the beginning of the conditional directive line, but a tab is not allowed. (If the line begins with a tab, it will be considered part of a recipe for a rule.)"

I also fixed a typo in the readme which said to define `MONITOR_PARMS = 8,1,n,N` instead of `MONITOR_PARAMS = 8,1,n,N`.
I also included python2 to the packages which should be installed for cygwin (as some version of python is at least required by pyserial). 
I also added MONITOR_PARMS to the documentation.