### PR TITLE
Rename `CTAGS_CMD` to `CTAGS_EXEC` (in the documentation).

### DIFF
--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -1878,16 +1878,16 @@ CTAGS_OPTS = -V
 
 ----
 
-### CTAGS_CMD
+### CTAGS_EXEC
 
 **Description:**
 
-Location of `ctags` binary. Defaults to user path.
+Path to the `ctags` binary. Defaults to user path.
 
 **Example:**
 
 ```Makefile
-CTAGS_CMD = /usr/local/bin/
+CTAGS_EXEC = /usr/local/bin/ctags
 ```
 
 **Requirement:** *Optional*


### PR DESCRIPTION
The former is not actually tweakable (anymore)