### PR TITLE
Test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build-cli
 /.project
 build-*
+.tags

--- a/Common.mk
+++ b/Common.mk
@@ -64,7 +64,7 @@ $(call show_config_variable,CURRENT_OS,[AUTODETECTED])
 ifneq ($(TEST),)
        DEPENDENCIES_DIR = /var/tmp/Arduino-Makefile-testing-dependencies
 
-       DEPENDENCIES_MPIDE_DIR = $(DEPENDENCIES_DIR)/mpide-0023-linux64-20130817-test
+       DEPENDENCIES_MPIDE_DIR = $(shell find $(DEPENDENCIES_DIR) -name 'mpide-0023-*' -type d -exec ls -dt {} + | head -n 1)
        ifeq ($(MPIDE_DIR),)
               MPIDE_DIR = $(DEPENDENCIES_MPIDE_DIR)
        endif

--- a/Common.mk
+++ b/Common.mk
@@ -69,7 +69,13 @@ ifneq ($(TEST),)
               MPIDE_DIR = $(DEPENDENCIES_MPIDE_DIR)
        endif
 
-       DEPENDENCIES_ARDUINO_DIR = $(DEPENDENCIES_DIR)/arduino-1.0.6
+       ifeq ($(CURRENT_OS),MAC)
+             IDE_DIRNAME=Arduino.app/Contents/Resources/Java
+       else
+             IDE_DIRNAME=arduino-1.0.6
+       endif
+
+       DEPENDENCIES_ARDUINO_DIR = $(DEPENDENCIES_DIR)/$(IDE_DIRNAME)
        ifeq ($(ARDUINO_DIR),)
               ARDUINO_DIR = $(DEPENDENCIES_ARDUINO_DIR)
        endif

--- a/tests/script/bootstrap/arduino.sh
+++ b/tests/script/bootstrap/arduino.sh
@@ -29,13 +29,15 @@ if [ -z "$ARDUINO_DIR" ] || ! test -e $ARDUINO_DIR || [ $OS == "cygwin" ]; then
         echo "Downloading Arduino IDE..."
         download $ARDUINO_URL $ARDUINO_FILE
 
-        if [[ ! "$(file --mime-type $ARDUINO_FILE)" =~ application\/zip ]]; then
+        download_type="$(file --mime-type $DEPENDENCIES_FOLDER/$ARDUINO_FILE)"
+        if [[ ! "$download_type" =~ application\/zip ]]; then
           mv $ARDUINO_FILE "bad-$ARDUINO_FILE"
 
           echo
           echo "[ERROR] Unable to download valid IDE for testing"
-          echo "  Download the IDE manually then try again."
+          echo "        Downloaded file should be a zip but is: ${download_type##* }."
           echo
+          echo "  Download the IDE manually then try again."
           echo "  Download from: https://www.arduino.cc/en/Main/Software"
           echo "  Save to      :  $DEPENDENCIES_FOLDER"
           exit 1

--- a/tests/script/bootstrap/arduino.sh
+++ b/tests/script/bootstrap/arduino.sh
@@ -30,7 +30,7 @@ if [ -z "$ARDUINO_DIR" ] || ! test -e $ARDUINO_DIR || [ $OS == "cygwin" ]; then
         download $ARDUINO_URL $ARDUINO_FILE
 
         download_type="$(file --mime-type $DEPENDENCIES_FOLDER/$ARDUINO_FILE)"
-        if [[ ! "$download_type" =~ application\/zip ]]; then
+        if [[ ! "$download_type" =~ zip ]]; then
           mv $ARDUINO_FILE "bad-$ARDUINO_FILE"
 
           echo

--- a/tests/script/bootstrap/arduino.sh
+++ b/tests/script/bootstrap/arduino.sh
@@ -9,6 +9,7 @@ if [ -z "$ARDUINO_DIR" ] || ! test -e $ARDUINO_DIR || [ $OS == "cygwin" ]; then
     echo "Installing Arduino..."
 
     ARDUINO_BASENAME="arduino-1.0.6"
+
     if [ $OS == "cygwin" ]; then
         ARDUINO_FILE="$ARDUINO_BASENAME-windows".zip
         EXTRACT_COMMAND="unzip -q"
@@ -20,13 +21,25 @@ if [ -z "$ARDUINO_DIR" ] || ! test -e $ARDUINO_DIR || [ $OS == "cygwin" ]; then
         EXTRACT_COMMAND="tar -xzf"
     fi
 
-    ARDUINO_URL=http://arduino.cc/download.php?f=/$ARDUINO_FILE
+    ARDUINO_URL=https://downloads.arduino.cc/$ARDUINO_FILE
 
     _pushd $DEPENDENCIES_FOLDER
     if ! test -e $ARDUINO_FILE
     then
         echo "Downloading Arduino IDE..."
         download $ARDUINO_URL $ARDUINO_FILE
+
+        if [[ ! "$(file --mime-type $ARDUINO_FILE)" =~ application\/zip ]]; then
+          mv $ARDUINO_FILE "bad-$ARDUINO_FILE"
+
+          echo
+          echo "[ERROR] Unable to download valid IDE for testing"
+          echo "  Download the IDE manually then try again."
+          echo
+          echo "  Download from: https://www.arduino.cc/en/Main/Software"
+          echo "  Save to      :  $DEPENDENCIES_FOLDER"
+          exit 1
+        fi
     fi
 
     if ! test -d $ARDUINO_BASENAME

--- a/tests/script/bootstrap/common.sh
+++ b/tests/script/bootstrap/common.sh
@@ -184,7 +184,7 @@ if [ -z $COMMON_SOURCED ]; then
         PIP_SUDO_CMD=$SUDO_CMD
     fi
 
-    $PIP_SUDO_CMD pip install --src dependencies --pre -Ur $BOOTSTRAP_DIR/pip-requirements.txt
+    $PIP_SUDO_CMD pip install --ignore-installed --src dependencies --pre -Ur $BOOTSTRAP_DIR/pip-requirements.txt
 
     COMMON_SOURCED=1
 fi

--- a/tests/script/runtests.sh
+++ b/tests/script/runtests.sh
@@ -1,10 +1,39 @@
 #!/usr/bin/env bash
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-pushd $SCRIPTS_DIR/../..
 TESTS_DIR=examples
 
 failures=()
+
+if [[ "$1" == "-q" ]]; then
+  QUIET=1
+fi
+
+runtest() {
+  if [[ $QUIET ]]; then
+    make $* TEST=1 > /dev/null 2>&1
+  else
+    output=`make $* TEST=1`
+  fi
+}
+
+run() {
+  if [[ $QUIET ]]; then
+    "$@" > /dev/null 2>&1
+  else
+    "$@"
+  fi
+}
+
+info() {
+  if [[ $QUIET ]]; then
+    return
+  fi
+
+  echo "$@"
+}
+
+run pushd $SCRIPTS_DIR/../..
 
 # These examples cannot be tested easily at the moment as they require
 # alternate cores. The MakefileExample doesn't actually contain any source code
@@ -24,46 +53,47 @@ do
     done
 
     if ! $example_is_testable; then
-        echo "Skipping non-testable example $example..."
+        info "Skipping non-testable example $example..."
         continue
     fi
 
-    pushd $dir
-    echo "Compiling $example..."
-    make_output=`make clean TEST=1`
-    make_output=`make TEST=1`
+    run pushd $dir
+    info "Compiling $example..."
+    runtest clean
+    runtest
+
     if [[ $? -ne 0 ]]; then
         failures+=("$example")
-        echo "Example $example failed"
+        info "Example $example failed"
     fi
 
-    make_output=`make disasm TEST=1`
+    runtest disasm
     if [[ $? -ne 0 ]]; then
         failures+=("$example disasm")
-        echo "Example $example disasm failed"
+        info "Example $example disasm failed"
     fi
 
-    make_output=`make generate_assembly TEST=1`
+    runtest generate_assembly
     if [[ $? -ne 0 ]]; then
         failures+=("$example generate_assembly")
-        echo "Example $example generate_assembly failed"
+        info "Example $example generate_assembly failed"
     fi
 
-    make_output=`make symbol_sizes TEST=1`
+    runtest symbol_sizes
     if [[ $? -ne 0 ]]; then
         failures+=("$example symbol_sizes")
-        echo "Example $example symbol_sizes failed"
+        info "Example $example symbol_sizes failed"
     fi
 
-    popd
-done
-
-for failure in "${failures[@]}"; do
-    echo "Example $failure failed"
+    run popd
 done
 
 if [[ ${#failures[@]} -eq 0 ]]; then
     echo "All tests passed."
 else
-    exit 1
+  for failure in "${failures[@]}"; do
+      echo "Example $failure failed"
+  done
+
+  exit 1
 fi

--- a/tests/script/runtests.sh
+++ b/tests/script/runtests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $SCRIPTS_DIR/../..
 TESTS_DIR=examples
 
 failures=()


### PR DESCRIPTION
Various fixes to test scripts:

bootstrap.sh
- Update the download link. Also, check if the downloaded file is a zip file and print a sensible error message if not.

runtests.sh
- Set the directory that the script can be run from anywhere
- Add a -q option for quiet mode

Common.mk
- Fix the DEPENDENCIES_ARDUINO_DIR for mac
- Instead of hardcoding the DEPENDENCIES_MPIDE_DIR, find the newest dir matching mpide-0023-* in DEPENDENCIES_ARDUINO_DIR