### PR TITLE
Let's make examples platform neutral

### DIFF
--- a/examples/ATtinyBlink/Makefile
+++ b/examples/ATtinyBlink/Makefile
@@ -54,6 +54,6 @@ BOARD_TAG = attiny85
 # ------------------------------------------------------------------ #
 
 # Path to the Arduino Makefile
-include /usr/share/arduino/Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk
 
 # !!! Important. You have to use 'make ispload' when using an ISP.

--- a/examples/AnalogInOutSerial/Makefile
+++ b/examples/AnalogInOutSerial/Makefile
@@ -1,4 +1,4 @@
 BOARD_TAG    = uno
 ARDUINO_LIBS =
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/Blink/Makefile
+++ b/examples/Blink/Makefile
@@ -1,7 +1,7 @@
 # Arduino Make file. Refer to https://github.com/sudar/Arduino-Makefile
 
 BOARD_TAG    = uno
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk
 
 
 

--- a/examples/Blink3rdPartyLib/Makefile
+++ b/examples/Blink3rdPartyLib/Makefile
@@ -15,7 +15,7 @@ TOGGLE_ARCHIVE = build-$(BOARD_TAG)/libtoggle.a
 CXXFLAGS += -IToggle
 OTHER_OBJS = Toggle/$(TOGGLE_ARCHIVE)
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk
 
 Toggle/$(TOGGLE_ARCHIVE):
 	$(MAKE) -C Toggle $(TOGGLE_ARCHIVE)

--- a/examples/Blink3rdPartyLib/Toggle/Makefile
+++ b/examples/Blink3rdPartyLib/Toggle/Makefile
@@ -8,7 +8,7 @@
 # and archived into the build-$(BOARD_TAG)/libtoggle.a target.
 
 include ../board.mk
-include ../../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk
 
 build-$(BOARD_TAG)/libtoggle.a: $(LOCAL_OBJS)
 	$(AR) rcs $@ $(LOCAL_OBJS)

--- a/examples/BlinkChipKIT/Makefile
+++ b/examples/BlinkChipKIT/Makefile
@@ -1,5 +1,5 @@
 BOARD_TAG    = mega_pic32
 ARDUINO_LIBS =
 
-include ../../chipKIT.mk
+include $(ARDMK_DIR)/chipKIT.mk
 

--- a/examples/BlinkInAVRC/Makefile
+++ b/examples/BlinkInAVRC/Makefile
@@ -11,6 +11,6 @@ F_CPU = 8000000L
 ISP_PROG   = stk500v1
 AVRDUDE_ISP_BAUDRATE = 19200
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk
 
 # !!! Important. You have to use make ispload to upload when using ISP programmer

--- a/examples/BlinkNetworkRPi/Makefile
+++ b/examples/BlinkNetworkRPi/Makefile
@@ -16,7 +16,7 @@ AVRDUDE_CONF=/usr/local/etc/avrdude.conf
 FORCE_MONITOR_PORT=true
 MONITOR_PORT=/dev/spidev0.0
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk
 
 
 # Additional rules to use a remote Raspberry Pi programmer

--- a/examples/BlinkTeensy/Makefile
+++ b/examples/BlinkTeensy/Makefile
@@ -1,4 +1,4 @@
 BOARD_TAG    = teensy31
 ARDUINO_LIBS =
 
-include ../../Teensy.mk
+include $(ARDMK_DIR)/Teensy.mk

--- a/examples/BlinkWithoutDelay/Makefile
+++ b/examples/BlinkWithoutDelay/Makefile
@@ -1,4 +1,4 @@
 BOARD_TAG    = uno
 ARDUINO_LIBS =
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/Fade/Makefile
+++ b/examples/Fade/Makefile
@@ -1,4 +1,4 @@
 BOARD_TAG    = uno
 ARDUINO_LIBS =
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/HelloWorld/Makefile
+++ b/examples/HelloWorld/Makefile
@@ -1,4 +1,4 @@
 BOARD_TAG    = uno
 ARDUINO_LIBS = LiquidCrystal
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/MakefileExample/Makefile-3rd_party-board.mk
+++ b/examples/MakefileExample/Makefile-3rd_party-board.mk
@@ -52,5 +52,5 @@ ARDUINO_SKETCHBOOK  = $(HOME)/sketchbook
 ALTERNATE_CORE      = sparkfun
 BOARD_TAG           = promicro
 BOARD_SUB	    = 8MHzatmega32U4
-include /usr/share/arduino/Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk
 

--- a/examples/SerialPrint/Makefile
+++ b/examples/SerialPrint/Makefile
@@ -2,4 +2,4 @@
 
 BOARD_TAG    = uno
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/TinySoftWareSerial/Makefile
+++ b/examples/TinySoftWareSerial/Makefile
@@ -17,4 +17,4 @@ F_CPU        = 16000000L
 
 ARDUINO_LIBS = SoftwareSerial
 
-include /usr/share/arduino/Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/WebServer/Makefile
+++ b/examples/WebServer/Makefile
@@ -3,4 +3,4 @@
 BOARD_TAG    = uno
 ARDUINO_LIBS = Ethernet SPI
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/master_reader/Makefile
+++ b/examples/master_reader/Makefile
@@ -3,4 +3,4 @@
 BOARD_TAG    = uno
 ARDUINO_LIBS = Wire
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk

--- a/examples/toneMelody/Makefile
+++ b/examples/toneMelody/Makefile
@@ -1,4 +1,4 @@
 BOARD_TAG    = uno
 ARDUINO_LIBS =
 
-include ../../Arduino.mk
+include $(ARDMK_DIR)/Arduino.mk


### PR DESCRIPTION
Depending on platform,  ARDMK_DIR can be:
 * `../..`
* `/usr/local`
* `/usr/share/arduino/`
* `/home/username/Arduino-Makefile`
* ...

And `README.md` tells people to set up ARDMK_DIR environment variable to ease platform differences, we should follow it in examples. 

Here is my humble try.

This helps Debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949769