### PR TITLE
Add build.board to CPPFLAGS (if found)

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -817,6 +817,11 @@ ifeq ($(strip $(NO_CORE)),)
         endif
     endif
 
+    # some cores have a build.board
+    ifndef BUILD_BOARD
+        BUILD_BOARD = $(call PARSE_BOARD,$(BOARD_TAG),build.board)
+    endif
+
 endif
 
 # Everything gets built in here (include BOARD_TAG now)
@@ -1187,6 +1192,10 @@ ifneq ($(CATERINA),)
     ifdef USB_PRODUCT
         CPPFLAGS += -DUSB_PRODUCT='$(USB_PRODUCT)' -DUSB_MANUFACTURER='$(USB_MANUFACTURER)'
     endif
+endif
+
+ifneq ($(BUILD_BOARD),)
+    CPPFLAGS += -DARDUINO_$(BUILD_BOARD) "-DARDUINO_BOARD=\"$(BUILD_BOARD)\""
 endif
 
 # $(TOOL_PREFIX)-gcc version that we can do maths on

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Updated Arch instructions. (https://github.com/Akram-Chehaima)
 - New: Add support for Robotis OpenCR 1.0 boards.
 - New: Build the ArduinoCore API
+- New: Parse build.board from boards.txt and add to CPPFLAGS (https://github.com/sej7278)
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)


### PR DESCRIPTION
Most boards.txt use build.board these days, this parses it and adds to `CPPFLAGS`, works with 1.0 and 1.5+

Some libraries bundled with cores like ESP32 use this to identify the specific development board rather than just relying on arch/platform

Example output (yes, the weird quoting is intentional as the libraries look for a string):

```
-DARDUINO_AVR_ATTINYX5 "-DARDUINO_BOARD=\"AVR_ATTINYX5\""

-DARDUINO_AVR_MEGA2560 "-DARDUINO_BOARD=\"AVR_MEGA2560\""

-DARDUINO_AVR_SANGUINO "-DARDUINO_BOARD=\"AVR_SANGUINO\""

-DARDUINO_AVR_ATmega128 "-DARDUINO_BOARD=\"AVR_ATmega128\""

-DARDUINO_AVR_UNO "-DARDUINO_BOARD=\"AVR_UNO\""
```