### PR TITLE
Add -DARDUINO_{build.board} for compile options

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1173,6 +1173,7 @@ endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
 CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) -DARDUINO_$(BOARD) $(ARDUINO_ARCH_FLAG) \
+         "-DARDUINO_BOARD=\"$(BOARD)\"" \
         -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_CORE_PATH)/api -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1173,7 +1173,7 @@ endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
 CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) -DARDUINO_$(BOARD) $(ARDUINO_ARCH_FLAG) \
-         "-DARDUINO_BOARD=\"$(BOARD)\"" \
+         "-DARDUINO_BOARD=\"$(BOARD)\"" "-DARDUINO_VARIANT=\"$(VARIANT)\"" \
         -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_CORE_PATH)/api -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections

--- a/Arduino.mk
+++ b/Arduino.mk
@@ -674,6 +674,16 @@ ifeq ($(strip $(NO_CORE)),)
         $(call show_config_variable,VARIANT,[USER])
     endif
 
+    ifndef BOARD
+	BOARD := $(call PARSE_BOARD,$(BOARD_TAG),build.board)
+        ifndef BOARD
+            BOARD := $(shell echo $(ARCHITECTURE)_$(BOARD_TAG) | tr '[:lower:]' '[:upper:]')
+        endif
+        $(call show_config_variable,BOARD,[COMPUTED],(from build.board))
+    else
+        $(call show_config_variable,BOARD,[USER])
+    endif
+
     # see if we are a caterina device like leonardo or micro
     CATERINA := $(findstring caterina,$(call PARSE_BOARD,$(BOARD_TAG),menu.(chip|cpu).$(BOARD_SUB).bootloader.file))
     ifndef CATERINA
@@ -1162,7 +1172,7 @@ else
 endif
 
 # Using += instead of =, so that CPPFLAGS can be set per sketch level
-CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) $(ARDUINO_ARCH_FLAG) \
+CPPFLAGS      += -$(MCU_FLAG_NAME)=$(MCU) -DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) -DARDUINO_$(BOARD) $(ARDUINO_ARCH_FLAG) \
         -I$(ARDUINO_CORE_PATH) -I$(ARDUINO_CORE_PATH)/api -I$(ARDUINO_VAR_PATH)/$(VARIANT) \
         $(SYS_INCLUDES) $(PLATFORM_INCLUDES) $(USER_INCLUDES) -Wall -ffunction-sections \
         -fdata-sections

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,6 +35,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Add support for Robotis OpenCR 1.0 boards.
 - New: Build the ArduinoCore API
 - New: Support for Python 3 and multi-os Python installation using new PYTHON_CMD variable.
+- New: Add "ARDUINO_{build.board}" to be able to detect board type.
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)

--- a/arduino-mk-vars.md
+++ b/arduino-mk-vars.md
@@ -583,6 +583,26 @@ CORE = tiny
 
 ----
 
+### BOARD
+
+**Description:**
+
+Board identifier that passes to a compile option as -DARDUINO_$(BOARD).
+
+Usually can be auto-detected as `build.board` from `boards.txt`.
+
+If not found build.board entry, use upper-case converted "$(ARCHITECTURE)_$(BOARD_TAG)".
+
+**Example:**
+
+```Makefile
+BOARD = AVR_LEONARD
+```
+
+**Requirement:** *Optional*
+
+----
+
 ### VARIANT
 
 **Description:**


### PR DESCRIPTION
ARDUINO_{build.board} macro used for detect board types.
(Always defined in Arduino IDE)

Usually provided by build.board in boards.txt.
Use upper case $(ARCH)_$(BOARD_TAG) uses for this value if missing build.board.