### PR TITLE
Use C++ compiler when linking for SAMD-based boards

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1674,9 +1674,9 @@ pre-build:
 
 # copied from arduino with start-group, end-group
 $(TARGET_ELF): 	$(LOCAL_OBJS) $(CORE_LIB) $(OTHER_OBJS)
-# sam devices need start and end group
+# sam devices need start and end group, and must be linked using C++ compiler
 ifeq ($(findstring sam, $(strip $(ARCHITECTURE))), sam)
-		$(CC) $(LINKER_SCRIPTS) -Wl,-Map=$(OBJDIR)/$(TARGET).map -o $@ $(LOCAL_OBJS) $(OTHER_OBJS) $(OTHER_LIBS) $(LDFLAGS) $(CORE_LIB) -Wl,--end-group
+		$(CXX) $(LINKER_SCRIPTS) -Wl,-Map=$(OBJDIR)/$(TARGET).map -o $@ $(LOCAL_OBJS) $(OTHER_OBJS) $(OTHER_LIBS) $(LDFLAGS) $(CORE_LIB) -Wl,--end-group
 # otherwise traditional
 else
 		$(CC) $(LDFLAGS) -o $@ $(LOCAL_OBJS) $(OTHER_OBJS) $(OTHER_LIBS) $(CORE_LIB) -lc -lm $(LINKER_SCRIPTS)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Grab USB_PRODUCT and USB_MANUFACTURER from boards.txt for 32u4 boards (issue #594).
 - Fix: Show the configuration when ARDUINO_QUIET=0
 - Fix: Travis build and bring Arduino IDE upto date
+- Fix: Builds for SAMD-based boards use the C++ compiler for linking (issue #644). (https://github.com/kpfleming)
 - Tweak: Move chip erase flag from set_fuses to ispload to prevent sketch being nuked when setting fuses
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - Tweak: Move non-standard-related items from CxxFLAGS_STD to CxxFLAGS (issue #523) (https://github.com/sej7278)


### PR DESCRIPTION
The Arduino IDE supports full usage of C++ (including the standard
library) on SAMD-based boards, so the final linking of the executable
must be done using the C++ compiler.

Closes #644.