### PR TITLE
Improve detection of ard-reset-arduino location

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -863,12 +863,13 @@ endif
 # Reset
 
 ifndef RESET_CMD
-  ARD_RESET_ARDUINO := $(PYTHON_CMD) $(shell which ard-reset-arduino 2> /dev/null)
-  ifndef ARD_RESET_ARDUINO
+  ARD_RESET_ARDUINO_PATH := $(shell which ard-reset-arduino 2> /dev/null)
+  ifndef ARD_RESET_ARDUINO_PATH
     # same level as *.mk in bin directory when checked out from git
     # or in $PATH when packaged
-    ARD_RESET_ARDUINO = $(PYTHON_CMD) $(ARDMK_DIR)/bin/ard-reset-arduino
+    ARD_RESET_ARDUINO_PATH = $(ARDMK_DIR)/bin/ard-reset-arduino
   endif
+  ARD_RESET_ARDUINO := $(PYTHON_CMD) $(ARD_RESET_ARDUINO_PATH)
   ifneq (,$(findstring CYGWIN,$(shell uname -s)))
       # confirm user is using default cygwin unix Python (which uses ttySx) and not Windows Python (which uses COMx)
       ifeq ($(PYTHON_CMD),/usr/bin/python)
@@ -879,6 +880,9 @@ ifndef RESET_CMD
     else
         RESET_CMD = $(ARD_RESET_ARDUINO) $(ARD_RESET_OPTS) $(call get_monitor_port)
     endif
+    $(call show_config_variable,RESET_CMD,[COMPUTED],(from PYTHON_CMD, ARD_RESET_OPTS and MONITOR_PORT))
+else
+    $(call show_config_variable,RESET_CMD,[USER])
 endif
 
 ifneq ($(CATERINA),)


### PR DESCRIPTION
Find location of ard-reset-arduino before prefixing it with PYTHON_CMD (so that 'which' failure can be detected). Also display the resulting RESET_CMD, or user-provided RESET_CMD.

Prior to this patch the `ifndef ARD_RESET_ARDUINO` would never be triggered because ARD_RESET_ARDUINO contained the value of PYTHON_CMD, even if the 'which' operation failed.