### PR TITLE
Support OpenCR Windows upload with cygwin and arduino zero board upload

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1733,7 +1733,7 @@ do_upload:
 
 do_sam_upload:  $(TARGET_BIN) verify_size
 ifeq ($(findstring openocd, $(strip $(UPLOAD_TOOL))), openocd)
-		$(OPENOCD) $(OPENOCD_OPTS) -c "telnet_port disabled; program {{$(TARGET_BIN)}} verify reset $(BOOTLOADER_SIZE); shutdown"
+		$(OPENOCD) $(OPENOCD_OPTS) -c "telnet_port disabled; program $(TARGET_BIN) verify reset $(BOOTLOADER_SIZE); shutdown"
 else ifeq ($(findstring bossac, $(strip $(UPLOAD_TOOL))), bossac)
 		$(BOSSA) $(BOSSA_OPTS) $(TARGET_BIN)
 else ifeq ($(findstring gdb, $(strip $(UPLOAD_TOOL))), gdb)

--- a/OpenCR.mk
+++ b/OpenCR.mk
@@ -3,6 +3,7 @@
 # Support for Robotis OpenCR boards 
 #
 # Written by Dowhan Jeong, EunJin Jeong
+# Changed by Woosuk Kang
 #
 # Based on work that is copyright Jeremy Shaw, Sudar, Nicholas Zambetti,
 # David A. Mellis & Hernando Barragan.
@@ -205,7 +206,7 @@ ifeq ($(CURRENT_OS), WINDOWS)
 else
     override AVRDUDE = $(ARDUINO_PACKAGE_DIR)/OpenCR/tools/opencr_tools/1.0.0/linux/opencr_ld
 endif
-override AVRDUDE_COM_OPTS = $(DEVICE_PATH) 
+override AVRDUDE_COM_OPTS = $(MONITOR_PORT) 
 override AVRDUDE_ISP_OPTS = 115200 $(TARGET_HEX) 1
 override AVRDUDE_ISPLOAD_OPTS = 
 


### PR DESCRIPTION
1. For using Arduino makefile with cygwin environment, OpenCR uses its own Windows binary to upload an image to the board. For this reason, the Windows COM port is needed as an argument instead of using a converted device path.
So, MONITOR_PORT is used to upload binary on the OpenCR board.

2. When uploading a bin file to the arduino zero board, there is an opening fail for a file in the argument of openocd due to the double braces. So removed the braces in the argument.