### PR TITLE
Remove code that uses pyserial_version

### DIFF
--- a/bin/ard-reset-arduino
+++ b/bin/ard-reset-arduino
@@ -100,11 +100,7 @@ elif args.caterina:
     if args.verbose: print('Forcing reset using 1200bps open/close on port %s' % args.port[0])
     ser = serial.Serial(args.port[0], 57600)
     ser.close()
-
-    if pyserial_version < 3:
-      ser.setBaudrate (1200)
-    else:
-      ser.baudrate = 1200
+    ser.baudrate = 1200
 
     ser.open()
     ser.setRTS(True)  # RTS line needs to be held high and DTR low


### PR DESCRIPTION
Since the python3 migration pyserial_version is no longer available.
This was missing in commit 207253abc.