### PR TITLE
Allow turning off LTO

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1243,13 +1243,20 @@ CXXFLAGS      += -fpermissive -fno-exceptions $(CXXFLAGS_STD)
 ASFLAGS       += -x assembler-with-cpp
 DIAGNOSTICS_COLOR_WHEN ?= always
 
+LTO ?= y
 # Flags for AVR
 ifeq ($(findstring avr, $(strip $(CC_NAME))), avr)
     ifeq ($(shell expr $(CC_VERNUM) '>' 490), 1)
-        ASFLAGS  += -flto
-        CXXFLAGS += -fno-threadsafe-statics -flto -fno-devirtualize -fdiagnostics-color=$(DIAGNOSTICS_COLOR_WHEN)
-        CFLAGS   += -flto -fno-fat-lto-objects -fdiagnostics-color=$(DIAGNOSTICS_COLOR_WHEN)
-        LDFLAGS += -flto -fuse-linker-plugin
+        ifeq ($(LTO), y)
+                LTO_ASFLAGS = -flto
+                LTO_CXXFLAGS = -flto
+                LTO_CFLAGS = -flto -fno-fat-lto-objects
+                LTO_LDFLAGS = -flto
+        endif
+        ASFLAGS  += $(LTO_ASFLAGS)
+        CXXFLAGS += -fno-threadsafe-statics $(LTO_CXXFLAGS) -fno-devirtualize -fdiagnostics-color=$(DIAGNOSTICS_COLOR_WHEN)
+        CFLAGS   += $(LTO_CFLAGS) -fdiagnostics-color=$(DIAGNOSTICS_COLOR_WHEN)
+        LDFLAGS += $(LTO_LDFLAGS) -fuse-linker-plugin
     endif
 # Flags for ARM (most set in Sam.mk)
 else


### PR DESCRIPTION
By default LTO (Link Time Optimization) of AVR GCC is enabled. On
atmega328p this remove most of the debugging data from the ELF file.
As a result avr-gdb can not be used fully.
For example lets take the simple Hello World application:

	#include <Arduino.h>

	void setup() {
	  Serial1.begin(9600);
	}

	void loop() {
	  Serial1.print("Hello World\n");
	}

following output shows that nither Print.c nither the test_app.cpp
are writen in the ELF file as a referance to the source code for
debugging porpose (the code is compiled with -g):

	$ avr-objdump -x build-a-star328PB/test_app.elf | grep df
	00000000 l    df *ABS*  00000000 malloc.c
	00000000 l    df *ABS*  00000000
	00000000 l    df *ABS*  00000000 _clear_bss.o
	00000000 l    df *ABS*  00000000
	00000000 l    df *ABS*  00000000 realloc.c
	00000000 l    df *ABS*  00000000 _udivmodsi4.o
	00000000 l    df *ABS*  00000000 _exit.o

As a result this ELF file can not be used by GDB. It can not find the
source code of the currently executed code.

When we disable the LTO the output is:

	$ avr-objdump -x build-a-star328PB/test_app.elf | grep df
	00000000 l    df *ABS*  00000000 test_app.cpp
	00000000 l    df *ABS*  00000000 Print.cpp
	00000000 l    df *ABS*  00000000 HardwareSerial.cpp
	00000000 l    df *ABS*  00000000 _clear_bss.o
	00000000 l    df *ABS*  00000000 main.cpp
	00000000 l    df *ABS*  00000000 wiring.c
	00000000 l    df *ABS*  00000000 new.cpp
	00000000 l    df *ABS*  00000000 _udivmodsi4.o
	00000000 l    df *ABS*  00000000 _exit.o
	00000000 l    df *ABS*  00000000

Now all source files are depicted by the ELF file. As a result avr-gdb
can use this ELF file for debugging. It depict the current source line.

Also the size of the .text section (Flash memory) is not optimiezed.
With LTO the simple Helloe World take 20264 bytes (.text). While the
build without LTO generate 3860 bytes (.text) for atmega328p.

This patch allow disabling of LTO by setting LTO=n. While keeping
LTO on by default.

Signed-off-by: Ivo Shopov <ivoshopov@gmail.com>