### PR TITLE
Fix: 'grep: warning: stray \ before #' in GNU grep >= 3.8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,5 +32,5 @@ At this point you're waiting on us to merge your pull request. We'll review all 
 # Additional Resources
 
 - [General GitHub Documentation](http://help.github.com/)
-- [GitHub Pull Request documentation](http://help.github.com/send-pull-requests/)
+- [GitHub Pull Request documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
 - [Guide about contributing code in GitHub](http://sudarmuthu.com/blog/contributing-to-project-hosted-in-github)

--- a/Common.mk
+++ b/Common.mk
@@ -8,7 +8,7 @@ dir_if_exists = $(if $(wildcard $(1)$(2)),$(1))
 # result = $(call READ_BOARD_TXT, 'boardname', 'parameter')
 PARSE_BOARD = $(shell if [ -f $(BOARDS_TXT) ]; \
 then \
-  $(GREP_CMD) -Ev '^\#' $(BOARDS_TXT) | \
+  $(GREP_CMD) -Ev '^#' $(BOARDS_TXT) | \
   $(GREP_CMD) -E "^[ \t]*$(1).$(2)=" | \
   cut -d = -f 2- | \
   cut -d : -f 2; \

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - Fix: Show the configuration when ARDUINO_QUIET=0
 - Fix: Travis build and bring Arduino IDE upto date
 - Fix: Builds for SAMD-based boards use the C++ compiler for linking (issue #644). (https://github.com/kpfleming)
+- Fix: 'grep: warning: stray \ before #' in GNU grep >= 3.8
 - Tweak: Move chip erase flag from set_fuses to ispload to prevent sketch being nuked when setting fuses
 - Tweak: Set ARDMK_VERSION to 1.6 (https://github.com/sej7278)
 - Tweak: Move non-standard-related items from CxxFLAGS_STD to CxxFLAGS (issue #523) (https://github.com/sej7278)


### PR DESCRIPTION
After upgrading GNU grep in Debian from 3.6 to 3.8, I get lots of "grep: warning: stray \ before #" warnings. This fixes it.