### PR TITLE
Fix format flag for avr-size command

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1260,7 +1260,7 @@ else
 endif
 
 LDFLAGS       += -$(MCU_FLAG_NAME)=$(MCU) -Wl,--gc-sections -O$(OPTIMIZATION_LEVEL)
-SIZEFLAGS     ?= --mcu=$(MCU) -C
+SIZEFLAGS     ?= --mcu=$(MCU) --format=avr
 
 # for backwards compatibility, grab ARDUINO_PORT if the user has it set
 # instead of MONITOR_PORT

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,7 @@ I tried to give credit whenever possible. If I have missed anyone, kindly add it
 - New: Build the ArduinoCore API
 - New: Support for Python 3 and multi-os Python installation using new PYTHON_CMD variable.
 - New: Add "ARDUINO_{build.board}" to be able to detect board type.
+- Fix: Update format flag for `avr-size` command (pull #686)
 
 ### 1.6.0 (2017-07-11)
 - Fix: Allowed for SparkFun's weird usb pid/vid submenu shenanigans (issue #499). (https://github.com/sej7278)


### PR DESCRIPTION
I was unable to compile programs because the `avr-size` command failed saying that "C is an unrecognised option".

It seems like `avr-size` no longer recognises the `-C` option; you have to pass in the full form of `--format=avr` instead. My workaround for now is to add the following line to my `Makefile`:

```makefile
SIZEFLAGS     ?= --mcu=$(MCU) --format=avr
```

However, updating the line here should fix it for everyone (and if I'm not wrong, it'll even be backwards-compatible with older versions of `avr-size` that would've still recognised the old `-C` option!)